### PR TITLE
Vertical swipe feed with mock posts and lifecycle hooks

### DIFF
--- a/lib/data/repos/feed_repository.dart
+++ b/lib/data/repos/feed_repository.dart
@@ -1,1 +1,41 @@
-// TODO: feed repository
+import '../models/post.dart';
+import '../models/author.dart';
+
+abstract class FeedRepository {
+  Stream<List<Post>> watchFeed();
+  Future<List<Post>> fetchInitial();
+}
+
+/// Mock implementation for development and tests
+class MockFeedRepository implements FeedRepository {
+  final int count;
+  MockFeedRepository({this.count = 10});
+
+  @override
+  Future<List<Post>> fetchInitial() async {
+    return List.generate(
+        count,
+        (i) => Post(
+              id: 'evt_\$i',
+              author: const Author(
+                  pubkey: 'pk',
+                  name: 'Creator',
+                  avatarUrl: 'https://picsum.photos/64'),
+              caption: 'Sample video #\$i',
+              tags: const ['demo'],
+              url:
+                  'https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4',
+              thumb: 'https://picsum.photos/seed/\$i/300/533',
+              mime: 'video/mp4',
+              width: 1080,
+              height: 1920,
+              duration: 10 + i.toDouble(),
+              createdAt: DateTime.now().subtract(Duration(minutes: i)),
+            ));
+  }
+
+  @override
+  Stream<List<Post>> watchFeed() async* {
+    yield await fetchInitial();
+  }
+}

--- a/lib/state/feed_controller.dart
+++ b/lib/state/feed_controller.dart
@@ -1,1 +1,39 @@
-// TODO: feed state controller
+import 'package:flutter/foundation.dart';
+import '../data/models/post.dart';
+import '../data/repos/feed_repository.dart';
+
+/// Minimal controller. Replace with Riverpod later if desired.
+class FeedController extends ChangeNotifier {
+  final FeedRepository repo;
+  FeedController(this.repo);
+
+  final List<Post> _posts = [];
+  int _index = 0;
+
+  List<Post> get posts => List.unmodifiable(_posts);
+  int get index => _index;
+
+  /// For tests and UI hints: indices we want to preload (±1)
+  Set<int> get preloadCandidates {
+    final s = <int>{};
+    if (_posts.isEmpty) return s;
+    if (_index - 1 >= 0) s.add(_index - 1);
+    if (_index + 1 < _posts.length) s.add(_index + 1);
+    return s;
+  }
+
+  Future<void> loadInitial() async {
+    final data = await repo.fetchInitial();
+    _posts
+      ..clear()
+      ..addAll(data);
+    _index = 0;
+    notifyListeners();
+  }
+
+  void onPageChanged(int i) {
+    if (i == _index) return;
+    _index = i;
+    notifyListeners();
+  }
+}

--- a/lib/ui/home/home_feed_page.dart
+++ b/lib/ui/home/home_feed_page.dart
@@ -9,28 +9,23 @@ class HomeFeedPage extends StatefulWidget {
 }
 
 class _HomeFeedPageState extends State<HomeFeedPage> {
-  bool playing = true; // mocked for now
-  bool overlaysVisible = true; // wired to controller later
+  bool overlaysVisible = true;
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       body: Stack(
         children: [
-          // Video layer (will become PageView in PR 3)
           GestureDetector(
             behavior: HitTestBehavior.opaque,
-            onTap: () => setState(() => playing = !playing),
-            onDoubleTap: () {
-              // TODO: trigger mock like + heart animation
-            },
-            onLongPress: () => setState(() => overlaysVisible = !overlaysVisible),
-            child: const VideoPlayerView(), // placeholder black screen
+            onTap: () {}, // play/pause will wire later
+            onDoubleTap: () {}, // like will wire later
+            onLongPress: () =>
+                setState(() => overlaysVisible = !overlaysVisible),
+            child: const VideoPlayerView(),
           ),
-          // Scrims
           const _GradientScrim(top: true),
           const _GradientScrim(top: false),
-          // Overlays
           AnimatedOpacity(
             duration: const Duration(milliseconds: 220),
             opacity: overlaysVisible ? 1 : 0,

--- a/lib/ui/home/widgets/video_card.dart
+++ b/lib/ui/home/widgets/video_card.dart
@@ -1,1 +1,42 @@
-// TODO: video card widget
+import 'package:flutter/material.dart';
+import '../../../data/models/post.dart';
+
+class VideoCard extends StatelessWidget {
+  final Post post;
+  final bool isCurrent;
+  final bool isNeighbour;
+  const VideoCard(
+      {super.key,
+      required this.post,
+      required this.isCurrent,
+      required this.isNeighbour});
+
+  @override
+  Widget build(BuildContext context) {
+    // Placeholder for a real video. Show a thumb and basic labels.
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        // In PR 4+, replace with actual video player. For now, coloured box.
+        Image.network(post.thumb,
+            fit: BoxFit.cover,
+            errorBuilder: (_, __, ___) => Container(color: Colors.black)),
+        Align(
+          alignment: Alignment.bottomLeft,
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: Text(
+              '\${post.caption}\n\${isCurrent ? "Playing" : isNeighbour ? "Preloaded" : "Idle"}',
+              maxLines: 3,
+              overflow: TextOverflow.ellipsis,
+              style: const TextStyle(
+                  fontSize: 12,
+                  color: Colors.white,
+                  shadows: [Shadow(blurRadius: 8)]),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ui/home/widgets/video_player_view.dart
+++ b/lib/ui/home/widgets/video_player_view.dart
@@ -1,10 +1,58 @@
 import 'package:flutter/material.dart';
+import '../../../state/feed_controller.dart';
+import '../../../data/repos/feed_repository.dart';
+import '../../../data/models/post.dart';
+import 'video_card.dart';
 
-class VideoPlayerView extends StatelessWidget {
+class VideoPlayerView extends StatefulWidget {
   const VideoPlayerView({super.key});
+
+  @override
+  State<VideoPlayerView> createState() => _VideoPlayerViewState();
+}
+
+class _VideoPlayerViewState extends State<VideoPlayerView> {
+  late final FeedController controller;
+  final PageController pageController = PageController();
+
+  @override
+  void initState() {
+    super.initState();
+    controller = FeedController(MockFeedRepository());
+    controller.addListener(_onController);
+    controller.loadInitial();
+  }
+
+  void _onController() {
+    if (mounted) setState(() {});
+  }
+
+  @override
+  void dispose() {
+    controller.removeListener(_onController);
+    pageController.dispose();
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
-    // Placeholder; real PageView and players arrive in PR 3
-    return Container(color: Colors.black);
+    final posts = controller.posts;
+    if (posts.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    return PageView.builder(
+      controller: pageController,
+      scrollDirection: Axis.vertical,
+      onPageChanged: controller.onPageChanged,
+      itemCount: posts.length,
+      itemBuilder: (context, i) {
+        final Post p = posts[i];
+        final isCurrent = i == controller.index;
+        final isNeighbour = controller.preloadCandidates.contains(i);
+        return VideoCard(
+            post: p, isCurrent: isCurrent, isNeighbour: isNeighbour);
+      },
+    );
   }
 }

--- a/test/state/feed_controller_preload_test.dart
+++ b/test/state/feed_controller_preload_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_video/state/feed_controller.dart';
+import 'package:nostr_video/data/repos/feed_repository.dart';
+
+void main() {
+  test('preloadCandidates returns ±1 within bounds', () async {
+    final c = FeedController(MockFeedRepository(count: 5));
+    await c.loadInitial();
+    // index 0 -> {1}
+    expect(c.index, 0);
+    expect(c.preloadCandidates, {1});
+    // move to 2 -> {1,3}
+    c.onPageChanged(2);
+    expect(c.preloadCandidates, {1, 3});
+    // last index -> {3}
+    c.onPageChanged(4);
+    expect(c.preloadCandidates, {3});
+  });
+}

--- a/test/ui/vertical_swipe_feed_test.dart
+++ b/test/ui/vertical_swipe_feed_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:nostr_video/ui/home/home_feed_page.dart';
+
+void main() {
+  testWidgets('vertical swipe updates current index', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: HomeFeedPage()));
+    // Wait for initial load
+    await tester.pump(const Duration(milliseconds: 100));
+    await tester.pumpAndSettle();
+
+    // Initial page should be index 0 visually
+    expect(find.textContaining('Playing'), findsOneWidget);
+
+    // Swipe up to next item
+    await tester.fling(find.byType(PageView), const Offset(0, -400), 1000);
+    await tester.pumpAndSettle();
+
+    // Should now show Playing on a different card
+    expect(find.textContaining('Playing'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- Build a mock feed repository and controller that tracks the current index and preload candidates.
- Add VideoPlayerView with vertical PageView and simple VideoCard placeholders that mark playing/preloaded/idle states.
- Wire HomeFeedPage to use the controller-driven PageView while keeping overlay cluster and scrims.

![swipe demo](https://placehold.co/300x600.gif?text=Swipe+Demo)

## Testing
- `flutter pub get`
- `flutter analyze`
- `flutter test`

## Checklist
- [x] PageView.builder renders a vertical feed of mock posts
- [x] Current page marked “Playing”, neighbours “Preloaded”, others “Idle`
- [x] Swiping updates the current index and labels
- [x] Controller exposes correct preload candidates (±1 within bounds)
- [x] Overlays from PR 2 remain visible and on top, with long-press toggle
- [x] CI green

------
https://chatgpt.com/codex/tasks/task_e_689c6bad57c083318eff88c55e5900f6