### PR TITLE
Real video playback with controller pooling; create → feed wiring

### DIFF
--- a/lib/ui/home/video_controller_pool.dart
+++ b/lib/ui/home/video_controller_pool.dart
@@ -1,0 +1,44 @@
+typedef Ctor<T> = Future<T> Function(String url);
+typedef Disposer<T> = Future<void> Function(T controller);
+typedef Player<T> = Future<void> Function(T controller, {required bool play});
+
+/// Generic, testable pool that keeps controllers for `keep` indices only.
+class ControllerPool<T> {
+  final Ctor<T> ctor;
+  final Disposer<T> dispose;
+  final Map<int, T> _map = {};
+
+  ControllerPool({required this.ctor, required this.dispose});
+
+  Future<Map<int, T>> ensureFor({
+    required Map<int, String> indexToUrl,
+    required Set<int> keep,
+  }) async {
+    // Dispose controllers we no longer want
+    final toDispose = _map.keys.where((k) => !keep.contains(k)).toList();
+    for (final k in toDispose) {
+      await dispose(_map[k] as T);
+      _map.remove(k);
+    }
+    // Ensure we have controllers for desired indices
+    for (final k in keep) {
+      if (!_map.containsKey(k)) {
+        final url = indexToUrl[k];
+        if (url == null) continue;
+        _map[k] = await ctor(url);
+      }
+    }
+    return Map<int, T>.unmodifiable(_map);
+  }
+
+  int get size => _map.length;
+
+  T? operator [](int i) => _map[i];
+
+  Future<void> clear() async {
+    for (final e in _map.entries) {
+      await dispose(e.value);
+    }
+    _map.clear();
+  }
+}

--- a/lib/ui/home/widgets/real_video_view.dart
+++ b/lib/ui/home/widgets/real_video_view.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import 'package:video_player/video_player.dart';
+
+class RealVideoView extends StatefulWidget {
+  const RealVideoView({super.key, required this.controller, required this.isActive, required this.isPlaying});
+  final VideoPlayerController controller;
+  final bool isActive;   // within ±1 window
+  final bool isPlaying;  // current item and not globally paused
+
+  @override
+  State<RealVideoView> createState() => _RealVideoViewState();
+}
+
+class _RealVideoViewState extends State<RealVideoView> with AutomaticKeepAliveClientMixin {
+  @override
+  void initState() {
+    super.initState();
+    _maybePlayPause();
+  }
+
+  @override
+  void didUpdateWidget(covariant RealVideoView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    _maybePlayPause();
+  }
+
+  Future<void> _maybePlayPause() async {
+    if (!widget.controller.value.isInitialized) return;
+    if (widget.isPlaying) {
+      await widget.controller.play();
+    } else {
+      await widget.controller.pause();
+      await widget.controller.seekTo(Duration.zero);
+    }
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    super.build(context);
+    if (!widget.controller.value.isInitialized) {
+      return const ColoredBox(color: Colors.black);
+    }
+    return FittedBox(
+      fit: BoxFit.cover,
+      child: SizedBox(
+        width: widget.controller.value.size.width,
+        height: widget.controller.value.size.height,
+        child: VideoPlayer(widget.controller),
+      ),
+    );
+  }
+
+  @override
+  bool get wantKeepAlive => true;
+}

--- a/lib/ui/home/widgets/video_card.dart
+++ b/lib/ui/home/widgets/video_card.dart
@@ -1,39 +1,40 @@
 import 'package:flutter/material.dart';
+import 'package:video_player/video_player.dart';
 import '../../../data/models/post.dart';
+import 'real_video_view.dart';
 
 class VideoCard extends StatelessWidget {
   final Post post;
   final bool isCurrent;
   final bool isNeighbour;
-  const VideoCard(
-      {super.key,
-      required this.post,
-      required this.isCurrent,
-      required this.isNeighbour});
+  final VideoPlayerController? controller; // null if not active
+  final bool globalPaused;
+  const VideoCard({
+    super.key,
+    required this.post,
+    required this.isCurrent,
+    required this.isNeighbour,
+    required this.controller,
+    required this.globalPaused,
+  });
 
   @override
   Widget build(BuildContext context) {
-    // Placeholder for a real video. Show a thumb and basic labels.
+    final isPlaying = isCurrent && !globalPaused && controller != null;
     return Stack(
       fit: StackFit.expand,
       children: [
-        // In PR 4+, replace with actual video player. For now, coloured box.
-        Image.network(post.thumb,
-            fit: BoxFit.cover,
-            errorBuilder: (_, __, ___) => Container(color: Colors.black)),
-        Align(
-          alignment: Alignment.bottomLeft,
-          child: Padding(
-            padding: const EdgeInsets.all(12),
-            child: Text(
-              '\${post.caption}\n\${isCurrent ? "Playing" : isNeighbour ? "Preloaded" : "Idle"}',
-              maxLines: 3,
-              overflow: TextOverflow.ellipsis,
-              style: const TextStyle(
-                  fontSize: 12,
-                  color: Colors.white,
-                  shadows: [Shadow(blurRadius: 8)]),
-            ),
+        if (controller != null)
+          RealVideoView(controller: controller!, isActive: isCurrent || isNeighbour, isPlaying: isPlaying)
+        else
+          // Not active: black placeholder to save resources
+          const ColoredBox(color: Colors.black),
+        // Optional tiny label for tests/dev
+        Positioned(
+          left: 8, top: 8,
+          child: Text(
+            isPlaying ? 'Playing' : (isNeighbour ? 'Preloaded' : 'Idle'),
+            style: const TextStyle(fontSize: 10, color: Colors.white),
           ),
         ),
       ],

--- a/lib/ui/home/widgets/video_player_view.dart
+++ b/lib/ui/home/widgets/video_player_view.dart
@@ -1,9 +1,6 @@
 import 'dart:async';
-import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:video_player/video_player.dart';
-import 'package:video_player_platform_interface/video_player_platform_interface.dart';
-import 'package:video_player_platform_interface/src/fake_video_player_platform.dart';
 import '../../../state/feed_controller.dart';
 import '../../../data/repos/feed_repository.dart';
 import '../../../data/models/post.dart';
@@ -34,10 +31,6 @@ class _VideoPlayerViewState extends State<VideoPlayerView> with WidgetsBindingOb
     Locator.I.put<FeedController>(controller);
     controller.addListener(_onController);
     controller.loadInitial();
-
-    if (Platform.environment.containsKey('FLUTTER_TEST')) {
-      VideoPlayerPlatform.instance = FakeVideoPlayerPlatform();
-    }
 
     pool = ControllerPool<VideoPlayerController>(
       ctor: (url) async {

--- a/lib/ui/home/widgets/video_player_view.dart
+++ b/lib/ui/home/widgets/video_player_view.dart
@@ -1,56 +1,107 @@
+import 'dart:async';
+import 'dart:io';
 import 'package:flutter/material.dart';
+import 'package:video_player/video_player.dart';
+import 'package:video_player_platform_interface/video_player_platform_interface.dart';
+import 'package:video_player_platform_interface/src/fake_video_player_platform.dart';
 import '../../../state/feed_controller.dart';
 import '../../../data/repos/feed_repository.dart';
 import '../../../data/models/post.dart';
+import '../video_controller_pool.dart';
 import 'video_card.dart';
 import '../../../core/di/locator.dart';
 
 class VideoPlayerView extends StatefulWidget {
-  const VideoPlayerView({super.key});
+  const VideoPlayerView({super.key, required this.globalPaused});
+  final bool globalPaused; // paused by sheet or app lifecycle
 
   @override
   State<VideoPlayerView> createState() => _VideoPlayerViewState();
 }
 
-class _VideoPlayerViewState extends State<VideoPlayerView> {
+class _VideoPlayerViewState extends State<VideoPlayerView> with WidgetsBindingObserver {
   late final FeedController controller;
   final PageController pageController = PageController();
-  final Set<int> _active = <int>{}; // simulate active video controllers
-  int get _current => controller.index;
+
+  late final ControllerPool<VideoPlayerController> pool;
+  Timer? _initDebounce;
 
   @override
   void initState() {
     super.initState();
+    WidgetsBinding.instance.addObserver(this);
     controller = FeedController(MockFeedRepository());
     Locator.I.put<FeedController>(controller);
-    controller.addListener(() {
-      _refreshActive();
-      _onController();
-    });
-    controller.loadInitial().then((_) => _refreshActive());
+    controller.addListener(_onController);
+    controller.loadInitial();
+
+    if (Platform.environment.containsKey('FLUTTER_TEST')) {
+      VideoPlayerPlatform.instance = FakeVideoPlayerPlatform();
+    }
+
+    pool = ControllerPool<VideoPlayerController>(
+      ctor: (url) async {
+        final c = VideoPlayerController.networkUrl(Uri.parse(url));
+        await c.initialize();
+        await c.setLooping(true);
+        await c.setVolume(1.0);
+        return c;
+        },
+      dispose: (c) async {
+        await c.pause();
+        await c.dispose();
+      },
+    );
+
+    // Warm initial controllers after first data load
+    _initDebounce = Timer(const Duration(milliseconds: 100), _refreshPool);
   }
 
-  void _refreshActive() {
-    final desired = <int>{};
-    if (controller.posts.isNotEmpty) {
-      desired.add(_current);
-      if (_current - 1 >= 0) desired.add(_current - 1);
-      if (_current + 1 < controller.posts.length) desired.add(_current + 1);
+  @override
+  void didUpdateWidget(covariant VideoPlayerView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Pause/resume current on global toggle
+    _refreshPool();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // Pause on inactive/paused; resume on resumed (handled via globalPaused wireup by parent if needed)
+    if (state == AppLifecycleState.paused || state == AppLifecycleState.inactive) {
+      setState(() {}); // cause RealVideoView rebuild with isPlaying=false
     }
-    _active
-      ..removeWhere((i) => !desired.contains(i))
-      ..addAll(desired);
-    if (mounted) setState(() {});
   }
 
   void _onController() {
+    if (mounted) setState(() {});
+    _refreshPool();
+  }
+
+  Future<void> _refreshPool() async {
+    if (!mounted) return;
+    final posts = controller.posts;
+    if (posts.isEmpty) return;
+    final idx = controller.index;
+    final keep = <int>{idx};
+    if (idx - 1 >= 0) keep.add(idx - 1);
+    if (idx + 1 < posts.length) keep.add(idx + 1);
+
+    // Map urls for the keep set only
+    final m = <int, String>{ for (final i in keep) i : posts[i].url };
+
+    await pool.ensureFor(indexToUrl: m, keep: keep);
+
+    // Auto play/pause current based on global state is handled in RealVideoView
     if (mounted) setState(() {});
   }
 
   @override
   void dispose() {
+    _initDebounce?.cancel();
     controller.removeListener(_onController);
     pageController.dispose();
+    pool.clear();
+    WidgetsBinding.instance.removeObserver(this);
     super.dispose();
   }
 
@@ -70,22 +121,26 @@ class _VideoPlayerViewState extends State<VideoPlayerView> {
           scrollDirection: Axis.vertical,
           onPageChanged: (i) {
             controller.onPageChanged(i);
-            _refreshActive();
           },
           itemCount: posts.length,
           itemBuilder: (context, i) {
             final Post p = posts[i];
             final isCurrent = i == controller.index;
             final isNeighbour = controller.preloadCandidates.contains(i);
-            return VideoCard(post: p, isCurrent: isCurrent, isNeighbour: isNeighbour);
+            final ctl = pool[i];
+            return VideoCard(
+              post: p,
+              isCurrent: isCurrent,
+              isNeighbour: isNeighbour,
+              controller: ctl,
+              globalPaused: widget.globalPaused,
+            );
           },
         ),
+        // Debug: show active controller count
         Positioned(
-          right: 8,
-          top: 8,
-          child: Text('${_active.length}',
-              key: const Key('active-controllers'),
-              style: const TextStyle(fontSize: 10)),
+          right: 8, top: 8,
+          child: Text('${pool.size}', key: const Key('active-controllers'), style: const TextStyle(fontSize: 10)),
         ),
       ],
     );

--- a/test/perf/active_controllers_limited_test.dart
+++ b/test/perf/active_controllers_limited_test.dart
@@ -1,8 +1,12 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_video/ui/home/home_feed_page.dart';
+import '../test_utils/fake_video_player_platform.dart';
 
 void main() {
+  setUpAll(() {
+    FakeVideoPlayerPlatform.register();
+  });
   testWidgets('keeps at most 3 active controllers (±1)', (tester) async {
     await tester.pumpWidget(const MaterialApp(home: HomeFeedPage()));
     await tester.pumpAndSettle();

--- a/test/perf/overlay_toggle_no_rebuild_test.dart
+++ b/test/perf/overlay_toggle_no_rebuild_test.dart
@@ -1,8 +1,12 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_video/ui/home/home_feed_page.dart';
+import '../test_utils/fake_video_player_platform.dart';
 
 void main() {
+  setUpAll(() {
+    FakeVideoPlayerPlatform.register();
+  });
   testWidgets('overlay toggle does not remove feed PageView', (tester) async {
     await tester.pumpWidget(const MaterialApp(home: HomeFeedPage()));
     await tester.pumpAndSettle();

--- a/test/test_utils/fake_video_player_platform.dart
+++ b/test/test_utils/fake_video_player_platform.dart
@@ -1,0 +1,80 @@
+import 'dart:async';
+import 'package:flutter/widgets.dart';
+import 'package:video_player_platform_interface/video_player_platform_interface.dart';
+
+class FakeVideoPlayerPlatform extends VideoPlayerPlatform {
+  int _textureCounter = 0;
+  final Map<int, StreamController<VideoEvent>> _controllers = {};
+  final Map<int, Duration> _positions = {};
+
+  static void register() {
+    VideoPlayerPlatform.instance = FakeVideoPlayerPlatform();
+  }
+
+  @override
+  Future<void> init() async {
+    _controllers.clear();
+    _positions.clear();
+  }
+
+  @override
+  Future<int?> create(DataSource dataSource) async {
+    final id = _textureCounter++;
+    final controller = StreamController<VideoEvent>();
+    _controllers[id] = controller;
+    _positions[id] = Duration.zero;
+    scheduleMicrotask(() {
+      controller.add(VideoEvent(
+        eventType: VideoEventType.initialized,
+        duration: const Duration(seconds: 1),
+        size: const Size(100, 100),
+      ));
+    });
+    return id;
+  }
+
+  @override
+  Stream<VideoEvent> videoEventsFor(int textureId) {
+    return _controllers[textureId]!.stream;
+  }
+
+  @override
+  Future<void> dispose(int textureId) async {
+    await _controllers[textureId]?.close();
+    _controllers.remove(textureId);
+    _positions.remove(textureId);
+  }
+
+  @override
+  Future<void> setLooping(int textureId, bool looping) async {}
+
+  @override
+  Future<void> play(int textureId) async {}
+
+  @override
+  Future<void> pause(int textureId) async {}
+
+  @override
+  Future<void> setVolume(int textureId, double volume) async {}
+
+  @override
+  Future<void> seekTo(int textureId, Duration position) async {
+    _positions[textureId] = position;
+  }
+
+  @override
+  Future<void> setPlaybackSpeed(int textureId, double speed) async {}
+
+  @override
+  Future<Duration> getPosition(int textureId) async {
+    return _positions[textureId] ?? Duration.zero;
+  }
+
+  @override
+  Widget buildView(int textureId) {
+    return const SizedBox.shrink();
+  }
+
+  @override
+  Future<void> setMixWithOthers(bool mixWithOthers) async {}
+}

--- a/test/ui/controller_pool_logic_test.dart
+++ b/test/ui/controller_pool_logic_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_video/ui/home/video_controller_pool.dart';
+
+class FakeCtl { bool disposed = false; }
+void main() {
+  test('pool keeps only desired indices', () async {
+    final pool = ControllerPool<FakeCtl>(
+      ctor: (url) async => FakeCtl(),
+      dispose: (c) async => c.disposed = true,
+    );
+
+    final map = {0:'a',1:'b',2:'c',3:'d'};
+    await pool.ensureFor(indexToUrl: map, keep: {1,2});
+    expect(pool.size, 2);
+    await pool.ensureFor(indexToUrl: map, keep: {2,3});
+    expect(pool.size, 2);
+  });
+}

--- a/test/ui/create_sheet_pause_test.dart
+++ b/test/ui/create_sheet_pause_test.dart
@@ -1,8 +1,12 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:nostr_video/ui/home/home_feed_page.dart';
+import '../test_utils/fake_video_player_platform.dart';
 
 void main() {
+  setUpAll(() {
+    FakeVideoPlayerPlatform.register();
+  });
   testWidgets('opening create sheet pauses playback (banner visible)', (tester) async {
     await tester.pumpWidget(const MaterialApp(home: HomeFeedPage()));
     // Open the sheet by tapping the FAB

--- a/test/ui/overlay_toggle_test.dart
+++ b/test/ui/overlay_toggle_test.dart
@@ -5,6 +5,7 @@ import '../test_utils/fake_video_player_platform.dart';
 
 void main() {
   setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
     FakeVideoPlayerPlatform.register();
   });
   testWidgets('long-press hides and shows overlays', (tester) async {

--- a/test/ui/overlay_toggle_test.dart
+++ b/test/ui/overlay_toggle_test.dart
@@ -1,8 +1,12 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:nostr_video/ui/home/home_feed_page.dart';
+import '../test_utils/fake_video_player_platform.dart';
 
 void main() {
+  setUpAll(() {
+    FakeVideoPlayerPlatform.register();
+  });
   testWidgets('long-press hides and shows overlays', (tester) async {
     await tester.pumpWidget(const MaterialApp(home: HomeFeedPage()));
     // Start visible

--- a/test/ui/overlays_default_hidden_test.dart
+++ b/test/ui/overlays_default_hidden_test.dart
@@ -2,8 +2,12 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:nostr_video/ui/home/home_feed_page.dart';
+import '../test_utils/fake_video_player_platform.dart';
 
 void main() {
+  setUpAll(() {
+    FakeVideoPlayerPlatform.register();
+  });
   testWidgets('overlays are hidden on open when setting is true', (
     tester,
   ) async {

--- a/test/ui/pause_flag_flows_to_view_test.dart
+++ b/test/ui/pause_flag_flows_to_view_test.dart
@@ -1,8 +1,12 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_video/ui/home/home_feed_page.dart';
+import '../test_utils/fake_video_player_platform.dart';
 
 void main() {
+  setUpAll(() {
+    FakeVideoPlayerPlatform.register();
+  });
   testWidgets('paused flag toggles without removing PageView', (tester) async {
     await tester.pumpWidget(const MaterialApp(home: HomeFeedPage()));
     await tester.pumpAndSettle();

--- a/test/ui/pause_flag_flows_to_view_test.dart
+++ b/test/ui/pause_flag_flows_to_view_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:nostr_video/ui/home/home_feed_page.dart';
+
+void main() {
+  testWidgets('paused flag toggles without removing PageView', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: HomeFeedPage()));
+    await tester.pumpAndSettle();
+    final pv = find.byKey(const Key('feed-pageview'));
+    expect(pv, findsOneWidget);
+    // Long-press overlays to ensure no rebuild of PageView
+    await tester.longPress(find.byType(GestureDetector));
+    await tester.pumpAndSettle();
+    expect(pv, findsOneWidget);
+  });
+}

--- a/test/ui/pause_flag_flows_to_view_test.dart
+++ b/test/ui/pause_flag_flows_to_view_test.dart
@@ -4,6 +4,7 @@ import 'package:nostr_video/ui/home/home_feed_page.dart';
 import '../test_utils/fake_video_player_platform.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   setUpAll(() {
     FakeVideoPlayerPlatform.register();
   });
@@ -13,7 +14,7 @@ void main() {
     final pv = find.byKey(const Key('feed-pageview'));
     expect(pv, findsOneWidget);
     // Long-press overlays to ensure no rebuild of PageView
-    await tester.longPress(find.byType(GestureDetector));
+    await tester.longPress(find.byKey(const Key('feed-gesture')));
     await tester.pumpAndSettle();
     expect(pv, findsOneWidget);
   });

--- a/test/ui/vertical_swipe_feed_test.dart
+++ b/test/ui/vertical_swipe_feed_test.dart
@@ -5,6 +5,7 @@ import '../test_utils/fake_video_player_platform.dart';
 
 void main() {
   setUpAll(() {
+    TestWidgetsFlutterBinding.ensureInitialized();
     FakeVideoPlayerPlatform.register();
   });
   testWidgets('vertical swipe updates current index', (tester) async {

--- a/test/ui/vertical_swipe_feed_test.dart
+++ b/test/ui/vertical_swipe_feed_test.dart
@@ -1,8 +1,12 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:nostr_video/ui/home/home_feed_page.dart';
+import '../test_utils/fake_video_player_platform.dart';
 
 void main() {
+  setUpAll(() {
+    FakeVideoPlayerPlatform.register();
+  });
   testWidgets('vertical swipe updates current index', (tester) async {
     await tester.pumpWidget(const MaterialApp(home: HomeFeedPage()));
     // Wait for initial load


### PR DESCRIPTION
## Summary
- play real videos via `VideoPlayer` and keep only ±1 controllers alive
- pause playback when sheets open and insert new posts at top of feed
- add tests for controller pool logic and PageView stability

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689cf6ddcab48331890425e8928bf72d