### PR TITLE
Web/PWA readiness: autoplay-safe video, CSP, manifest, and PWA build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,6 @@ ios/
 linux/
 macos/
 windows/
-web/
+# Generated plugins
 .flutter-plugins
 .flutter-plugins-dependencies

--- a/docs/WEB.md
+++ b/docs/WEB.md
@@ -1,0 +1,16 @@
+# Web/PWA notes
+
+## Build
+```bash
+# dev
+flutter run -d chrome
+
+# prod (installable PWA)
+flutter build web --release --pwa-strategy=offline-first
+# if debugging service worker issues:
+# flutter build web --release --pwa-strategy=none
+```
+
+## Notes
+- Remote videos from relays/media hosts are fetched network-first and are not cached by the service worker.
+- `web/index.html` captures `beforeinstallprompt` so you can show an install button if desired.

--- a/lib/ui/home/widgets/real_video_view.dart
+++ b/lib/ui/home/widgets/real_video_view.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:video_player/video_player.dart';
 
 class RealVideoView extends StatefulWidget {
@@ -45,13 +46,23 @@ class _RealVideoViewState extends State<RealVideoView> with AutomaticKeepAliveCl
     if (!widget.controller.value.isInitialized) {
       return const ColoredBox(color: Colors.black);
     }
-    return FittedBox(
+    final player = FittedBox(
       fit: BoxFit.cover,
       child: SizedBox(
         width: widget.controller.value.size.width,
         height: widget.controller.value.size.height,
         child: VideoPlayer(widget.controller),
       ),
+    );
+    if (!kIsWeb) return player;
+    // On web: single tap toggles mute so users can enable sound per video.
+    return GestureDetector(
+      behavior: HitTestBehavior.opaque,
+      onTap: () async {
+        final v = widget.controller.value.volume;
+        await widget.controller.setVolume(v > 0 ? 0.0 : 1.0);
+      },
+      child: player,
     );
   }
 

--- a/lib/ui/home/widgets/video_player_view.dart
+++ b/lib/ui/home/widgets/video_player_view.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:video_player/video_player.dart';
 import '../../../state/feed_controller.dart';
 import '../../../data/repos/feed_repository.dart';
@@ -44,7 +45,8 @@ class _VideoPlayerViewState extends State<VideoPlayerView> with WidgetsBindingOb
           final c = VideoPlayerController.networkUrl(Uri.parse(url));
           await c.initialize();
           await c.setLooping(true);
-          await c.setVolume(1.0);
+          // Web allows autoplay only when muted.
+          await c.setVolume(kIsWeb ? 0.0 : 1.0);
           return c;
         },
         dispose: (c) async {

--- a/web/icons/README.md
+++ b/web/icons/README.md
@@ -1,0 +1,4 @@
+# Icons
+
+Place PWA icons (e.g., Icon-192.png) in this directory. They are referenced
+by `web/manifest.json` but omitted from source control.

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <base href="/">
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="manifest" href="manifest.json">
+    <meta name="theme-color" content="#000000">
+
+    <!-- Content Security Policy: allow your relays/upload/media origins -->
+    <!-- Replace RELAY_HOSTS and MEDIA_HOSTS with your actual domains -->
+    <meta http-equiv="Content-Security-Policy"
+      content="
+        default-src 'self';
+        connect-src 'self' https://* wss://*;
+        img-src 'self' https://* data: blob:;
+        media-src 'self' https://* blob: data:;
+        style-src 'self' 'unsafe-inline';
+        script-src 'self' 'wasm-unsafe-eval';
+        worker-src 'self' blob:;
+      ">
+
+    <title>ShortLived</title>
+  </head>
+  <body>
+    <script>
+      // Optional: minimal install prompt UX.
+      window.addEventListener('beforeinstallprompt', e => {
+        window.__pwaPrompt = e;
+      });
+    </script>
+    <script src="flutter_bootstrap.js" async></script>
+  </body>
+</html>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "ShortLived",
+  "short_name": "ShortLived",
+  "start_url": "/",
+  "display": "standalone",
+  "background_color": "#000000",
+  "theme_color": "#000000",
+  "icons": [
+    { "src": "icons/Icon-192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "icons/Icon-512.png", "sizes": "512x512", "type": "image/png" },
+    { "src": "icons/Icon-maskable-192.png", "sizes": "192x192", "type": "image/png", "purpose": "maskable" },
+    { "src": "icons/Icon-maskable-512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+  ]
+}


### PR DESCRIPTION
## Summary
- Mute autoplaying videos on web and allow tap-to-unmute
- Add PWA manifest, index with CSP, and icons placeholder
- Document web build and note service worker behavior

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689dbfc5865083318a4c52c87236427f