### PR TITLE
Relay List (NIP-65): read/write flags, sync, and management UI

### DIFF
--- a/lib/services/nostr/relay_directory.dart
+++ b/lib/services/nostr/relay_directory.dart
@@ -1,0 +1,154 @@
+import 'dart:async';
+import '../keys/key_service.dart';
+import '../nostr/relay_service.dart';
+import '../../crypto/nostr_event.dart';
+import '../settings/settings_service.dart';
+
+class RelayEntry {
+  final Uri uri;
+  final bool read;
+  final bool write;
+  const RelayEntry(this.uri, {this.read = true, this.write = true});
+
+  RelayEntry copyWith({bool? read, bool? write}) =>
+      RelayEntry(uri, read: read ?? this.read, write: write ?? this.write);
+}
+
+class RelayDirectory {
+  RelayDirectory(this._settings, this._relay, this._keys);
+  final SettingsService _settings;
+  final RelayService _relay;
+  final KeyService _keys;
+
+  List<RelayEntry> _list = [];
+
+  List<RelayEntry> current() => List.unmodifiable(_list);
+
+  /// Load local settings; then attempt remote import (kind:10002).
+  Future<void> init() async {
+    _list = _settings.loadRelays();
+    // Try pull remote list; if newer, replace local and persist.
+    final remote = await _fetchRemote();
+    if (remote != null) {
+      final remoteAt = remote.$2; // created_at
+      final localAt = _settings.relaysUpdatedAt();
+      if (remoteAt > localAt) {
+        _list = remote.$1;
+        await _settings.saveRelays(_list, updatedAt: remoteAt);
+      }
+    }
+    await _applyToRelay();
+  }
+
+  Future<void> add(String url, {bool read = true, bool write = true}) async {
+    final uri = Uri.parse(url);
+    if (_list.any((e) => e.uri == uri)) return;
+    _list = [..._list, RelayEntry(uri, read: read, write: write)];
+    await _persistAndPublish();
+  }
+
+  Future<void> remove(String url) async {
+    final uri = Uri.parse(url);
+    _list = _list.where((e) => e.uri != uri).toList();
+    await _persistAndPublish();
+  }
+
+  Future<void> setFlags(String url, {bool? read, bool? write}) async {
+    final uri = Uri.parse(url);
+    _list = _list
+        .map((e) => e.uri == uri ? e.copyWith(read: read, write: write) : e)
+        .toList();
+    await _persistAndPublish();
+  }
+
+  Future<void> _persistAndPublish() async {
+    final now = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    await _settings.saveRelays(_list, updatedAt: now);
+    await _publishKind10002(now);
+    await _applyToRelay();
+  }
+
+  Future<void> _applyToRelay() async {
+    final urls = _list
+        .where((e) => e.read || e.write)
+        .map((e) => e.uri.toString())
+        .toList();
+    if (urls.isEmpty) return;
+    await _relay.resetConnections(urls); // new method added below
+  }
+
+  /// Fetch remote kind:10002 for the current user; returns (list, created_at) or null.
+  Future<(List<RelayEntry>, int)?> _fetchRemote() async {
+    final pub = await _keys.getPubkey();
+    if (pub == null || pub.isEmpty) return null;
+    // Subscribe once for kind:10002 authored by pub; close after first EVENT or EOSE
+    final subId = await _relay.subscribe([
+      {
+        "kinds": [10002],
+        "authors": [pub],
+        "limit": 1,
+      }
+    ], subId: "nip65_self");
+
+    final completer = Completer<(List<RelayEntry>, int)?>();
+    late final StreamSubscription sub;
+    sub = _relay.events.listen((evt) {
+      if ((evt['kind'] as int?) == 10002 && (evt['pubkey'] as String?) == pub) {
+        final created = (evt['created_at'] ?? 0) as int;
+        final tags =
+            (evt['tags'] as List?)?.whereType<List>().toList() ?? const [];
+        final list = <RelayEntry>[];
+        for (final t in tags) {
+          if (t.isEmpty || t.first != 'r') continue;
+          final url = (t.length >= 2) ? t[1] as String : '';
+          if (url.isEmpty) continue;
+          final marker = (t.length >= 3) ? (t[2] as String).toLowerCase() : '';
+          final read = marker.isEmpty || marker == 'read' || marker == 'both';
+          final write = marker.isEmpty || marker == 'write' || marker == 'both';
+          list.add(RelayEntry(Uri.parse(url), read: read, write: write));
+        }
+        completer.complete((list, created));
+        sub.cancel();
+      }
+    }, onDone: () {
+      completer.complete(null);
+    }, onError: (_) {
+      completer.complete(null);
+    });
+
+    // Failsafe timeout
+    Future.delayed(const Duration(seconds: 2)).then((_) {
+      if (!completer.isCompleted) {
+        sub.cancel();
+        completer.complete(null);
+      }
+    });
+
+    final res = await completer.future;
+    await _relay.close(subId);
+    return res;
+  }
+
+  Future<void> _publishKind10002(int createdAt) async {
+    final priv = await _keys.getPrivkey();
+    final pub = await _keys.getPubkey();
+    if (priv == null || pub == null) return;
+
+    final tags = <List<String>>[
+      for (final e in _list)
+        if (e.read && e.write)
+          ['r', e.uri.toString()]
+        else if (e.read && !e.write)
+          ['r', e.uri.toString(), 'read']
+        else if (!e.read && e.write)
+          ['r', e.uri.toString(), 'write']
+        else
+          ...[]
+    ];
+
+    final e =
+        NostrEvent(kind: 10002, createdAt: createdAt, content: '', tags: tags);
+    final signed = NostrEvent.sign(priv, pub, e);
+    await _relay.publishEvent(signed);
+  }
+}

--- a/lib/services/nostr/relay_service.dart
+++ b/lib/services/nostr/relay_service.dart
@@ -1,10 +1,12 @@
 abstract class RelayService {
   Future<void> init(List<String> relays);
+
   /// Subscribe to feed using Nostr filters; returns a subscription id you can close later.
   Future<String> subscribe(List<Map<String, dynamic>> filters, {String? subId});
   Future<void> close(String subId);
   Stream<List<dynamic>> subscribeFeed(
       {required List<String> authors, String? hashtag});
+
   /// Publish already signed event JSON (has id/pubkey/sig).
   Future<String> publishEvent(Map<String, dynamic> signedEventJson);
 
@@ -30,6 +32,9 @@ abstract class RelayService {
     String content,
     List<String>? relays,
   });
+
+  /// NEW: reset the active connections to the provided relay URLs
+  Future<void> resetConnections(List<String> urls);
 
   // Future work: optionally expose a way to fetch user lists (e.g. mute list).
 }

--- a/test/moderation/mute_event_shape_test.dart
+++ b/test/moderation/mute_event_shape_test.dart
@@ -10,13 +10,16 @@ class _RelayNoop implements RelayService {
   Future<void> init(List<String> relays) async {}
 
   @override
-  Future<String> subscribe(List<Map<String, dynamic>> filters, {String? subId}) async => 's';
+  Future<String> subscribe(List<Map<String, dynamic>> filters,
+          {String? subId}) async =>
+      's';
 
   @override
   Future<void> close(String subId) async {}
 
   @override
-  Stream<List<dynamic>> subscribeFeed({required List<String> authors, String? hashtag}) =>
+  Stream<List<dynamic>> subscribeFeed(
+          {required List<String> authors, String? hashtag}) =>
       Stream<List<dynamic>>.empty();
 
   @override
@@ -38,10 +41,14 @@ class _RelayNoop implements RelayService {
   }) async {}
 
   @override
-  Future<void> zapRequest({required String eventId, required int millisats}) async {}
+  Future<void> zapRequest(
+      {required String eventId, required int millisats}) async {}
 
   @override
   Future<void> repost({required String eventId, String? originalJson}) async {}
+
+  @override
+  Future<void> resetConnections(List<String> urls) async {}
 
   @override
   Stream<Map<String, dynamic>> get events => const Stream.empty();
@@ -52,7 +59,8 @@ class _RelayNoop implements RelayService {
     required String eventId,
     String content = '',
     List<String>? relays,
-  }) async => {};
+  }) async =>
+      {};
 }
 
 class _KeysFake implements KeyService {

--- a/test/relays/merge_precedence_test.dart
+++ b/test/relays/merge_precedence_test.dart
@@ -1,0 +1,123 @@
+import 'dart:async';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_video/services/nostr/relay_directory.dart';
+import 'package:nostr_video/services/settings/settings_service.dart';
+import 'package:nostr_video/services/nostr/relay_service.dart';
+import 'package:nostr_video/services/keys/key_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class FakePrefs implements SharedPreferences {
+  final Map<String, Object> _store = {};
+  @override
+  List<String>? getStringList(String key) => _store[key] as List<String>?;
+  @override
+  Future<bool> setStringList(String key, List<String> value) async {
+    _store[key] = value;
+    return true;
+  }
+
+  @override
+  int? getInt(String key) => _store[key] as int?;
+  @override
+  Future<bool> setInt(String key, int value) async {
+    _store[key] = value;
+    return true;
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _RelayFake implements RelayService {
+  final _ctrl = StreamController<Map<String, dynamic>>.broadcast();
+  Map<String, dynamic>? published;
+  @override
+  Stream<Map<String, dynamic>> get events => _ctrl.stream;
+  @override
+  Future<String> subscribe(List<Map<String, dynamic>> f,
+          {String? subId}) async =>
+      's';
+  @override
+  Future<void> close(String subId) async {}
+  @override
+  Future<void> init(List<String> relays) async {}
+  @override
+  Stream<List<dynamic>> subscribeFeed(
+          {required List<String> authors, String? hashtag}) =>
+      const Stream.empty();
+  @override
+  Future<String> publishEvent(Map<String, dynamic> e) async {
+    published = e;
+    return 'id';
+  }
+
+  @override
+  Future<void> like({required String eventId}) async {}
+  @override
+  Future<void> reply(
+      {required String parentId,
+      required String content,
+      String? parentPubkey,
+      String? rootId,
+      String? rootPubkey}) async {}
+  @override
+  Future<void> repost({required String eventId, String? originalJson}) async {}
+  @override
+  Future<Map<String, dynamic>> buildZapRequest(
+          {required String recipientPubkey,
+          required String eventId,
+          String content = '',
+          List<String>? relays}) async =>
+      {};
+  @override
+  Future<void> resetConnections(List<String> urls) async {}
+  @override
+  Future<void> zapRequest(
+      {required String eventId, required int millisats}) async {}
+  void emit(Map<String, dynamic> evt) => _ctrl.add(evt);
+}
+
+class _Keys implements KeyService {
+  @override
+  Future<String?> getPrivkey() async => '11' * 32;
+  @override
+  Future<String?> getPubkey() async => '02' + 'a' * 66;
+  @override
+  Future<String> generate() async => '';
+  @override
+  Future<String> importSecret(String s) async => '';
+  @override
+  Future<String?> exportNsec() async => null;
+}
+
+class _SettingsMem extends SettingsService {
+  _SettingsMem(super.prefs);
+}
+
+void main() {
+  test('remote newer replaces local', () async {
+    final relay = _RelayFake();
+    final s = _SettingsMem(FakePrefs());
+    await s.saveRelays(
+        [RelayEntry(Uri.parse('wss://old'), read: true, write: true)],
+        updatedAt: 1);
+
+    final dir = RelayDirectory(s, relay, _Keys());
+    Future.delayed(const Duration(milliseconds: 10), () {
+      relay.emit({
+        'kind': 10002,
+        'pubkey': '02' + 'a' * 66,
+        'created_at': 999,
+        'tags': [
+          ['r', 'wss://new', 'read'],
+        ],
+      });
+    });
+    await dir.init();
+    expect(
+        dir
+            .current()
+            .any((e) => e.uri.toString() == 'wss://new' && e.read && !e.write),
+        true);
+  });
+}

--- a/test/relays/merge_precedence_test.dart
+++ b/test/relays/merge_precedence_test.dart
@@ -81,7 +81,7 @@ class _Keys implements KeyService {
   @override
   Future<String?> getPrivkey() async => '11' * 32;
   @override
-  Future<String?> getPubkey() async => '02' + 'a' * 66;
+  Future<String?> getPubkey() async => '02${'a' * 66}';
   @override
   Future<String> generate() async => '';
   @override
@@ -106,7 +106,7 @@ void main() {
     Future.delayed(const Duration(milliseconds: 10), () {
       relay.emit({
         'kind': 10002,
-        'pubkey': '02' + 'a' * 66,
+        'pubkey': '02${'a' * 66}',
         'created_at': 999,
         'tags': [
           ['r', 'wss://new', 'read'],

--- a/test/relays/nip65_event_shape_test.dart
+++ b/test/relays/nip65_event_shape_test.dart
@@ -78,7 +78,7 @@ class _KeysFake implements KeyService {
   @override
   Future<String?> getPrivkey() async => '11' * 32;
   @override
-  Future<String?> getPubkey() async => '02' + 'a' * 66;
+  Future<String?> getPubkey() async => '02${'a' * 66}';
   @override
   Future<String> generate() async => '';
   @override

--- a/test/relays/nip65_event_shape_test.dart
+++ b/test/relays/nip65_event_shape_test.dart
@@ -1,0 +1,110 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_video/services/nostr/relay_directory.dart';
+import 'package:nostr_video/services/nostr/relay_service.dart';
+import 'package:nostr_video/services/settings/settings_service.dart';
+import 'package:nostr_video/services/keys/key_service.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class FakePrefs implements SharedPreferences {
+  final Map<String, Object> _store = {};
+  @override
+  List<String>? getStringList(String key) => _store[key] as List<String>?;
+  @override
+  Future<bool> setStringList(String key, List<String> value) async {
+    _store[key] = value;
+    return true;
+  }
+
+  @override
+  int? getInt(String key) => _store[key] as int?;
+  @override
+  Future<bool> setInt(String key, int value) async {
+    _store[key] = value;
+    return true;
+  }
+
+  @override
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _RelaySpy implements RelayService {
+  Map<String, dynamic>? lastPublished;
+  @override
+  Future<String> publishEvent(Map<String, dynamic> e) async {
+    lastPublished = e;
+    return e['id'] as String? ?? 'id';
+  }
+
+  @override
+  Future<void> init(List<String> relays) async {}
+  @override
+  Future<String> subscribe(List<Map<String, dynamic>> f,
+          {String? subId}) async =>
+      's';
+  @override
+  Future<void> close(String subId) async {}
+  @override
+  Stream<List<dynamic>> subscribeFeed(
+          {required List<String> authors, String? hashtag}) =>
+      const Stream.empty();
+  @override
+  Stream<Map<String, dynamic>> get events => const Stream.empty();
+  @override
+  Future<void> like({required String eventId}) async {}
+  @override
+  Future<void> reply(
+      {required String parentId,
+      required String content,
+      String? parentPubkey,
+      String? rootId,
+      String? rootPubkey}) async {}
+  @override
+  Future<void> repost({required String eventId, String? originalJson}) async {}
+  @override
+  Future<Map<String, dynamic>> buildZapRequest(
+          {required String recipientPubkey,
+          required String eventId,
+          String content = '',
+          List<String>? relays}) async =>
+      {};
+  @override
+  Future<void> resetConnections(List<String> urls) async {}
+  @override
+  Future<void> zapRequest(
+      {required String eventId, required int millisats}) async {}
+}
+
+class _KeysFake implements KeyService {
+  @override
+  Future<String?> getPrivkey() async => '11' * 32;
+  @override
+  Future<String?> getPubkey() async => '02' + 'a' * 66;
+  @override
+  Future<String> generate() async => '';
+  @override
+  Future<String> importSecret(String s) async => '';
+  @override
+  Future<String?> exportNsec() async => null;
+}
+
+class _SettingsMem extends SettingsService {
+  _SettingsMem(super.prefs);
+}
+
+void main() {
+  test('publishes kind:10002 with r tags and markers', () async {
+    final relay = _RelaySpy();
+    final dir = RelayDirectory(_SettingsMem(FakePrefs()), relay, _KeysFake());
+    await dir.add('wss://a', read: true, write: false);
+    await dir.add('wss://b', read: false, write: true);
+    final e = relay.lastPublished!;
+    expect(e['kind'], 10002);
+    final tags = (e['tags'] as List).where((t) => t[0] == 'r').toList();
+    expect(
+        tags.any((t) => t[1] == 'wss://a' && t.length >= 3 && t[2] == 'read'),
+        true);
+    expect(
+        tags.any((t) => t[1] == 'wss://b' && t.length >= 3 && t[2] == 'write'),
+        true);
+  });
+}

--- a/test/repos/sort_and_dedupe_test.dart
+++ b/test/repos/sort_and_dedupe_test.dart
@@ -39,6 +39,9 @@ class _RelayFake implements RelayService {
   Future<void> repost({required String eventId, String? originalJson}) async {}
 
   @override
+  Future<void> resetConnections(List<String> urls) async {}
+
+  @override
   Future<Map<String, dynamic>> buildZapRequest(
           {required String recipientPubkey,
           required String eventId,

--- a/test/safety/overlay_toggle_icon_test.dart
+++ b/test/safety/overlay_toggle_icon_test.dart
@@ -59,6 +59,9 @@ class _RelayServiceStub implements RelayService {
   Stream<Map<String, dynamic>> get events => const Stream.empty();
 
   @override
+  Future<void> resetConnections(List<String> urls) async {}
+
+  @override
   Future<Map<String, dynamic>> buildZapRequest(
           {required String recipientPubkey,
           required String eventId,

--- a/test/search/trending_from_feed_test.dart
+++ b/test/search/trending_from_feed_test.dart
@@ -81,6 +81,9 @@ class FakeRelay implements RelayService {
   Stream<Map<String, dynamic>> get events => const Stream.empty();
 
   @override
+  Future<void> resetConnections(List<String> urls) async {}
+
+  @override
   Future<Map<String, dynamic>> buildZapRequest(
           {required String recipientPubkey,
           required String eventId,

--- a/test/state/like_optimistic_test.dart
+++ b/test/state/like_optimistic_test.dart
@@ -38,6 +38,9 @@ class _NoopRelay implements RelayService {
   Future<void> repost({required String eventId, String? originalJson}) async {}
 
   @override
+  Future<void> resetConnections(List<String> urls) async {}
+
+  @override
   Future<Map<String, dynamic>> buildZapRequest(
           {required String recipientPubkey,
           required String eventId,

--- a/test/state/replay_queue_test.dart
+++ b/test/state/replay_queue_test.dart
@@ -53,6 +53,9 @@ class _RelaySpy implements RelayService {
   Future<void> repost({required String eventId, String? originalJson}) async {}
 
   @override
+  Future<void> resetConnections(List<String> urls) async {}
+
+  @override
   Future<Map<String, dynamic>> buildZapRequest(
           {required String recipientPubkey,
           required String eventId,

--- a/test/state/repost_optimistic_test.dart
+++ b/test/state/repost_optimistic_test.dart
@@ -26,6 +26,8 @@ class _NoopRelay implements RelayService {
   @override
   Future<void> repost({required String eventId, String? originalJson}) async {}
   @override
+  Future<void> resetConnections(List<String> urls) async {}
+  @override
   Future<void> zapRequest(
       {required String eventId, required int millisats}) async {}
   @override

--- a/test/test_utils/test_services.dart
+++ b/test/test_utils/test_services.dart
@@ -61,6 +61,9 @@ class RelayServiceFake implements RelayService {
           String content = '',
           List<String>? relays}) async =>
       {};
+
+  @override
+  Future<void> resetConnections(List<String> urls) async {}
 }
 
 class KeyServiceFake implements KeyService {

--- a/test/threads/thread_repo_sort_dedupe_test.dart
+++ b/test/threads/thread_repo_sort_dedupe_test.dart
@@ -48,24 +48,40 @@ class _RelayEventsFake implements RelayService {
   @override
   Stream<Map<String, dynamic>> get events => _c.stream;
   @override
-  Future<String> subscribe(List<Map<String, dynamic>> filters,{String? subId}) async => 'sub';
+  Future<String> subscribe(List<Map<String, dynamic>> filters,
+          {String? subId}) async =>
+      'sub';
   @override
   Future<void> close(String subId) async {}
   // Unused methods
   @override
   Future<void> init(List<String> relays) async {}
   @override
-  Stream<List<dynamic>> subscribeFeed({required List<String> authors, String? hashtag}) async* {}
+  Stream<List<dynamic>> subscribeFeed(
+      {required List<String> authors, String? hashtag}) async* {}
   @override
   Future<String> publishEvent(Map<String, dynamic> signedEventJson) async => '';
   @override
   Future<void> like({required String eventId}) async {}
   @override
-  Future<void> reply({required String parentId, required String content, String? parentPubkey, String? rootId, String? rootPubkey}) async {}
+  Future<void> reply(
+      {required String parentId,
+      required String content,
+      String? parentPubkey,
+      String? rootId,
+      String? rootPubkey}) async {}
   @override
   Future<void> repost({required String eventId, String? originalJson}) async {}
   @override
-  Future<void> zapRequest({required String eventId, required int millisats}) async {}
+  Future<void> zapRequest(
+      {required String eventId, required int millisats}) async {}
   @override
-  Future<Map<String, dynamic>> buildZapRequest({required String recipientPubkey, required String eventId, String content = '', List<String>? relays}) async => {};
+  Future<void> resetConnections(List<String> urls) async {}
+  @override
+  Future<Map<String, dynamic>> buildZapRequest(
+          {required String recipientPubkey,
+          required String eventId,
+          String content = '',
+          List<String>? relays}) async =>
+      {};
 }

--- a/test/ui/relays_sheet_add_toggle_test.dart
+++ b/test/ui/relays_sheet_add_toggle_test.dart
@@ -1,10 +1,55 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:nostr_video/ui/sheets/relays_sheet.dart';
 import 'package:nostr_video/services/settings/settings_service.dart';
+import 'package:nostr_video/services/nostr/relay_directory.dart';
+import 'package:nostr_video/services/nostr/relay_service.dart';
 import 'package:nostr_video/services/keys/key_service.dart';
 import 'package:nostr_video/core/di/locator.dart';
+
+class _RelayStub implements RelayService {
+  @override
+  Future<void> init(List<String> relays) async {}
+  @override
+  Future<String> subscribe(List<Map<String, dynamic>> filters,
+          {String? subId}) async =>
+      's';
+  @override
+  Future<void> close(String subId) async {}
+  @override
+  Stream<List<dynamic>> subscribeFeed(
+          {required List<String> authors, String? hashtag}) =>
+      const Stream.empty();
+  @override
+  Future<String> publishEvent(Map<String, dynamic> signedEventJson) async =>
+      'id';
+  @override
+  Future<void> like({required String eventId}) async {}
+  @override
+  Future<void> reply(
+      {required String parentId,
+      required String content,
+      String? parentPubkey,
+      String? rootId,
+      String? rootPubkey}) async {}
+  @override
+  Future<void> repost({required String eventId, String? originalJson}) async {}
+  @override
+  Future<void> zapRequest(
+      {required String eventId, required int millisats}) async {}
+  @override
+  Stream<Map<String, dynamic>> get events => const Stream.empty();
+  @override
+  Future<Map<String, dynamic>> buildZapRequest(
+          {required String recipientPubkey,
+          required String eventId,
+          String content = '',
+          List<String>? relays}) async =>
+      {};
+  @override
+  Future<void> resetConnections(List<String> urls) async {}
+}
 
 class _KeyDummy implements KeyService {
   @override
@@ -20,42 +65,41 @@ class _KeyDummy implements KeyService {
 }
 
 void main() {
-  testWidgets('add relay and toggle overlays default', (tester) async {
+  testWidgets('add relay and toggle flags', (tester) async {
     SharedPreferences.setMockInitialValues({});
     final sp = await SharedPreferences.getInstance();
-    final s = SettingsService(sp);
-    Locator.I.put<KeyService>(_KeyDummy());
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: Builder(
-            builder: (context) {
-              return ElevatedButton(
-                onPressed: () => showModalBottomSheet(
-                  context: context,
-                  builder: (_) => RelaysSheet(settings: s),
-                ),
-                child: const Text('Open'),
-              );
-            },
+    final settings = SettingsService(sp);
+    final dir = RelayDirectory(settings, _RelayStub(), _KeyDummy());
+    Locator.I.put<RelayDirectory>(dir);
+
+    await tester.pumpWidget(MaterialApp(
+      home: Builder(
+        builder: (context) => ElevatedButton(
+          onPressed: () => showModalBottomSheet(
+            context: context,
+            builder: (_) => const RelaysSheet(),
           ),
+          child: const Text('Open'),
         ),
       ),
-    );
+    ));
 
     await tester.tap(find.text('Open'));
     await tester.pumpAndSettle();
 
-    // Add a relay
-    await tester.enterText(find.byKey(const Key('relay-url')), 'wss://example.com');
+    await tester.enterText(find.byType(TextField), 'wss://example.com');
     await tester.tap(find.text('Add'));
     await tester.pumpAndSettle();
 
-    // Toggle overlays default hidden
-    await tester.tap(find.byType(SwitchListTile));
+    expect(dir.current().any((e) => e.uri.toString() == 'wss://example.com'),
+        true);
+
+    await tester.tap(find.widgetWithText(FilterChip, 'Read'));
     await tester.pumpAndSettle();
 
-    expect(s.relays().contains('wss://example.com'), true);
-    expect(s.overlaysDefaultHidden(), true);
+    final entry = dir
+        .current()
+        .firstWhere((e) => e.uri.toString() == 'wss://example.com');
+    expect(entry.read, false);
   });
 }


### PR DESCRIPTION
## Summary
- implement `RelayDirectory` to manage relay lists and publish kind:10002 with read/write markers
- persist relay flags and timestamps in `SettingsService`
- add resetConnections to relay service and dynamic reconnection
- build RelaySheet UI for adding/removing relays and syncing from profile

https://example.com/clip.mp4

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_689ef780c90c833180775b824b6d8283