### PR TITLE
Key management UI (NIP-19): import/export nsec, QR show, rotate/clear

### DIFF
--- a/lib/crypto/nip19.dart
+++ b/lib/crypto/nip19.dart
@@ -60,3 +60,15 @@ class Nip19 {
     return result;
   }
 }
+
+String npubEncode(String pubkeyHex) => Nip19.encodeNpub(pubkeyHex);
+String nsecEncode(String privHex) => Nip19.encodeNsec(privHex);
+String? nip19Decode(String bech) {
+  try {
+    return Nip19.decode(bech);
+  } catch (_) {
+    return null;
+  }
+}
+bool isNpub(String s) => s.toLowerCase().startsWith('npub1');
+bool isNsec(String s) => s.toLowerCase().startsWith('nsec1');

--- a/lib/ui/home/home_feed_page.dart
+++ b/lib/ui/home/home_feed_page.dart
@@ -10,6 +10,7 @@ import '../sheets/details_sheet.dart';
 import '../sheets/relays_sheet.dart';
 import '../sheets/quote_sheet.dart';
 import '../sheets/search_sheet.dart';
+import '../sheets/settings_sheet.dart';
 import 'package:nostr_video/core/di/locator.dart';
 import '../../core/config/network.dart';
 import '../../services/nostr/relay_service_ws.dart';
@@ -200,6 +201,17 @@ class _HomeFeedPageState extends State<HomeFeedPage>
     _pausedBySheet.value = false;
   }
 
+  Future<void> _openSettings() async {
+    _pausedBySheet.value = true;
+    await showModalBottomSheet(
+      context: context,
+      backgroundColor: Colors.black,
+      isScrollControlled: true,
+      builder: (_) => const SettingsSheet(),
+    );
+    _pausedBySheet.value = false;
+  }
+
   Future<void> _openProfile() async {
     final p = _currentPost;
     if (p == null) return;
@@ -299,6 +311,7 @@ class _HomeFeedPageState extends State<HomeFeedPage>
                 onDetailsTap: _openDetails,
                 onRelaysLongPress: _openRelays,
                 onSearchTap: _openSearch,
+                onSettingsTap: _openSettings,
                 safetyOn: settings.sensitiveBlurEnabled(),
                 onSafetyToggle: _toggleSafety,
                 showInstall: avail,

--- a/lib/ui/home/widgets/overlay_cluster.dart
+++ b/lib/ui/home/widgets/overlay_cluster.dart
@@ -13,6 +13,7 @@ class OverlayCluster extends StatelessWidget {
     required this.onDetailsTap,
     required this.onRelaysLongPress,
     required this.onSearchTap,
+    required this.onSettingsTap,
     required this.safetyOn,
     required this.onSafetyToggle,
     this.showInstall = false,
@@ -28,6 +29,7 @@ class OverlayCluster extends StatelessWidget {
   final VoidCallback onDetailsTap;
   final VoidCallback onRelaysLongPress;
   final VoidCallback onSearchTap;
+  final VoidCallback onSettingsTap;
   final bool safetyOn;
   final VoidCallback onSafetyToggle;
   final bool showInstall;
@@ -59,7 +61,7 @@ class OverlayCluster extends StatelessWidget {
               child: IconButton(
                 icon: const Icon(Icons.blur_on),
                 tooltip: 'App',
-                onPressed: () {},
+                onPressed: onSettingsTap,
               ),
             ),
           ),

--- a/lib/ui/sheets/key_management_sheet.dart
+++ b/lib/ui/sheets/key_management_sheet.dart
@@ -1,0 +1,221 @@
+import 'package:flutter/material.dart';
+import '../../core/di/locator.dart';
+import '../../services/keys/key_service.dart';
+import '../../crypto/nip19.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+
+class KeyManagementSheet extends StatefulWidget {
+  const KeyManagementSheet({super.key});
+  @override
+  State<KeyManagementSheet> createState() => _KeyManagementSheetState();
+}
+
+class _KeyManagementSheetState extends State<KeyManagementSheet> {
+  String? _pubHex;
+  String? _privHex;
+  final _importCtrl = TextEditingController();
+  bool _busy = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final ks = Locator.I.tryGet<KeyService>();
+    if (ks == null) return;
+    final pub = await ks.getPubkey();
+    final priv = await ks.getPrivkey();
+    if (!mounted) return;
+    setState(() {
+      _pubHex = pub;
+      _privHex = priv;
+    });
+  }
+
+  Future<void> _generate() async {
+    if (_busy) return;
+    final ks = Locator.I.tryGet<KeyService>();
+    if (ks == null) return;
+    setState(() => _busy = true);
+    try {
+      await ks.generate();
+      await _load();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('New key generated')));
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _import() async {
+    if (_busy) return;
+    final ks = Locator.I.tryGet<KeyService>();
+    if (ks == null) return;
+    final raw = _importCtrl.text.trim();
+    if (raw.isEmpty) return;
+    setState(() => _busy = true);
+    try {
+      String? hex;
+      if (isNsec(raw)) {
+        hex = nip19Decode(raw);
+      } else if (RegExp(r'^[0-9a-fA-F]{64}$').hasMatch(raw)) {
+        hex = raw;
+      } else {
+        throw Exception('Paste an nsec… or 64-char hex secret');
+      }
+      await ks.importSecret(hex!);
+      await _load();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context)
+          .showSnackBar(const SnackBar(content: Text('Key imported')));
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Import failed: $e')));
+      }
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  Future<void> _clear() async {
+    if (_busy) return;
+    final ks = Locator.I.tryGet<KeyService>();
+    if (ks == null) return;
+    final ok = await showDialog<bool>(
+      context: context,
+      builder: (_) => AlertDialog(
+        title: const Text('Clear keys from this device?'),
+        content: const Text(
+            'You will not be able to publish until you import or generate a new key.'),
+        actions: [
+          TextButton(
+              onPressed: () => Navigator.pop(context, false),
+              child: const Text('Cancel')),
+          ElevatedButton(
+              onPressed: () => Navigator.pop(context, true),
+              child: const Text('Clear')),
+        ],
+      ),
+    );
+    if (ok != true) return;
+    setState(() => _busy = true);
+    try {
+      await ks.importSecret('');
+      await _load();
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(content: Text('Keys cleared on this device')));
+    } finally {
+      if (mounted) setState(() => _busy = false);
+    }
+  }
+
+  @override
+  void dispose() {
+    _importCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final pubHex = _pubHex;
+    final privHex = _privHex;
+    final npub =
+        (pubHex != null && pubHex.isNotEmpty) ? npubEncode(pubHex) : '';
+    final nsec =
+        (privHex != null && privHex.isNotEmpty) ? nsecEncode(privHex) : '';
+
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 20),
+        child: SingleChildScrollView(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                  height: 4,
+                  width: 36,
+                  margin: const EdgeInsets.only(bottom: 12),
+                  decoration: BoxDecoration(
+                      color: Colors.white24,
+                      borderRadius: BorderRadius.circular(2))),
+              const Text('Keys',
+                  style: TextStyle(fontWeight: FontWeight.bold)),
+              const SizedBox(height: 12),
+              const Text('Public key (npub)'),
+              const SizedBox(height: 6),
+              SelectableText(npub.isEmpty ? 'No local key' : npub,
+                  style: const TextStyle(fontFamily: 'monospace')),
+              const SizedBox(height: 8),
+              if (npub.isNotEmpty)
+                Center(
+                    child: QrImageView(
+                        data: npub,
+                        version: QrVersions.auto,
+                        size: 160)),
+              const SizedBox(height: 16),
+              const Text('Secret key (nsec)'),
+              const SizedBox(height: 6),
+              if (nsec.isEmpty)
+                const Text(
+                    'Not stored on this device (using browser signer or not generated).')
+              else
+                SelectableText(nsec,
+                    style: const TextStyle(
+                        fontFamily: 'monospace', color: Colors.orange)),
+              const SizedBox(height: 8),
+              if (nsec.isNotEmpty)
+                Center(
+                    child: QrImageView(
+                        data: nsec,
+                        version: QrVersions.auto,
+                        size: 160)),
+              if (nsec.isNotEmpty)
+                const Padding(
+                  padding: EdgeInsets.only(top: 6),
+                  child: Text(
+                      'Keep this private. Anyone with nsec can post as you.',
+                      style: TextStyle(color: Colors.redAccent)),
+                ),
+              const SizedBox(height: 16),
+              Row(children: [
+                Expanded(
+                  child: TextField(
+                    controller: _importCtrl,
+                    minLines: 1,
+                    maxLines: 3,
+                    decoration: const InputDecoration(
+                        hintText: 'Paste nsec… or 64-char hex to import'),
+                  ),
+                ),
+                const SizedBox(width: 8),
+                ElevatedButton(
+                    onPressed: _busy ? null : _import,
+                    child: const Text('Import')),
+              ]),
+              const SizedBox(height: 12),
+              Row(children: [
+                ElevatedButton(
+                    onPressed: _busy ? null : _generate,
+                    child: const Text('Generate new')),
+                const SizedBox(width: 8),
+                OutlinedButton(
+                    onPressed: _busy ? null : _clear,
+                    child: const Text('Clear from device')),
+              ]),
+              const SizedBox(height: 8),
+              const Text(
+                  'Note: On web you can also use a NIP-07 browser wallet (see Settings → Signer).'),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/ui/sheets/settings_sheet.dart
+++ b/lib/ui/sheets/settings_sheet.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'key_management_sheet.dart';
+
+class SettingsSheet extends StatelessWidget {
+  const SettingsSheet({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              height: 4,
+              width: 36,
+              margin: const EdgeInsets.only(bottom: 12),
+              decoration: BoxDecoration(
+                color: Colors.white24,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: const Text('Settings',
+                  style: TextStyle(fontWeight: FontWeight.bold)),
+            ),
+            ListTile(
+              leading: const Icon(Icons.vpn_key),
+              title: const Text('Key management'),
+              subtitle: const Text('Import/export, rotate, clear'),
+              onTap: () => showModalBottomSheet(
+                context: context,
+                backgroundColor: Colors.black,
+                isScrollControlled: true,
+                builder: (_) => const KeyManagementSheet(),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,7 @@ dependencies:
   ecdsa: ^0.1.2
   crypto: ^3.0.0
   bech32: ^0.2.2
+  qr_flutter: ^4.1.0
 
 dev_dependencies:
   flutter_test:

--- a/test/nip19/encode_decode_roundtrip_test.dart
+++ b/test/nip19/encode_decode_roundtrip_test.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_video/crypto/nip19.dart';
+
+void main() {
+  test('npub/nsec encode/decode roundtrip', () {
+    final priv = List.filled(32, '11').join();
+    final pub = List.filled(32, '22').join();
+    final nsec = nsecEncode(priv);
+    final npub = npubEncode(pub);
+    expect(nip19Decode(nsec), priv);
+    expect(nip19Decode(npub), pub);
+    expect(isNsec(nsec), true);
+    expect(isNpub(npub), true);
+  });
+}
+

--- a/test/ui/key_management_smoke_test.dart
+++ b/test/ui/key_management_smoke_test.dart
@@ -1,0 +1,13 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:nostr_video/ui/sheets/key_management_sheet.dart';
+
+void main() {
+  testWidgets('Key sheet renders', (tester) async {
+    await tester.pumpWidget(const MaterialApp(
+        home: Scaffold(body: KeyManagementSheet())));
+    expect(find.textContaining('Keys'), findsOneWidget);
+    expect(find.text('Generate new'), findsOneWidget);
+  });
+}
+


### PR DESCRIPTION
## Summary
- add minimal NIP-19 helpers with npub/nsec encode/decode helpers
- provide key management sheet for viewing, importing, generating and clearing keys with QR support
- expose settings sheet and hook it to the UI to launch key management
- include widget and NIP-19 roundtrip tests

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `flutter run -d chrome` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fa9ec29108331bf5b29581da25a48