### PR TITLE
Mentions & Notifications: replies, likes, reposts, zaps (basic)

### DIFF
--- a/lib/data/models/notification.dart
+++ b/lib/data/models/notification.dart
@@ -1,0 +1,24 @@
+enum NotificationType { reply, like, repost, zap }
+
+class NotificationItem {
+  final NotificationType type;
+  final String id;              // event id
+  final String fromPubkey;
+  final String fromName;        // filled from MetadataService when available
+  final String fromAvatar;      // optional
+  final String relatedEventId;  // the post they acted on (if any)
+  final String content;         // reply text or short label
+  final int createdAt;          // seconds since epoch (nostr)
+  final int? sats;              // for zaps (msats/1000 rounded)
+  const NotificationItem({
+    required this.type,
+    required this.id,
+    required this.fromPubkey,
+    required this.fromName,
+    required this.fromAvatar,
+    required this.relatedEventId,
+    required this.content,
+    required this.createdAt,
+    this.sats,
+  });
+}

--- a/lib/data/repos/notifications_repository.dart
+++ b/lib/data/repos/notifications_repository.dart
@@ -1,0 +1,104 @@
+import 'dart:async';
+import '../models/notification.dart';
+import '../../core/di/locator.dart'; // ignore: unused_import
+import '../../services/nostr/relay_service.dart';
+import '../../services/keys/signer.dart';
+import '../../services/nostr/metadata_service.dart';
+import '../../core/testing/test_switches.dart';
+
+class NotificationsRepository {
+  NotificationsRepository(this._relay, this._signer, this._meta);
+  final RelayService _relay;
+  final Signer _signer;
+  final MetadataService _meta;
+
+  StreamSubscription<Map<String, dynamic>>? _sub;
+  final _byId = <String, NotificationItem>{};
+  final _ctrl = StreamController<List<NotificationItem>>.broadcast();
+
+  Stream<List<NotificationItem>> stream() => _ctrl.stream;
+
+  Future<void> start() async {
+    if (TestSwitches.disableRelays) return;
+    final me = await _signer.getPubkey();
+    if (me == null || me.isEmpty) return;
+
+    // Subscribe to mentions/acts to me
+    await _relay.subscribe([
+      { "kinds": [1,6,7,9735], "#p": [me], "limit": 200 }
+    ], subId: 'notif_\$me');
+
+    _sub = _relay.events.listen((evt) {
+      final kind = (evt['kind'] ?? -1) as int;
+      if (kind != 1 && kind != 6 && kind != 7 && kind != 9735) return;
+
+      final id = (evt['id'] ?? '') as String; if (id.isEmpty) return;
+      if (_byId.containsKey(id)) return;
+
+      final pk = (evt['pubkey'] ?? '') as String;
+      final m = _meta.get(pk);
+      final name = m?.name ?? (pk.isNotEmpty ? pk.substring(0,8) : 'unknown');
+      final avatar = m?.picture ?? '';
+      final created = (evt['created_at'] ?? 0) as int;
+
+      // find related event id (first 'e' tag)
+      String related = '';
+      final tags = (evt['tags'] as List?)?.whereType<List>().toList() ?? const [];
+      for (final t in tags) {
+        if (t.isNotEmpty && t[0] == 'e' && t.length >= 2) { related = t[1] as String; break; }
+      }
+
+      NotificationType? t;
+      String content = '';
+      int? sats;
+
+      if (kind == 1) { // reply/mention
+        t = NotificationType.reply;
+        content = (evt['content'] ?? '') as String;
+      } else if (kind == 6) {
+        t = NotificationType.repost;
+        content = 'reposted your post';
+      } else if (kind == 7) {
+        t = NotificationType.like;
+        content = 'liked your post';
+      } else if (kind == 9735) {
+        t = NotificationType.zap;
+        // msats in tag or 'amount' field (varies by relays)
+        final amtTag = tags.firstWhere(
+          (x) => x.isNotEmpty && x[0] == 'amount',
+          orElse: () => const [],
+        );
+        int msats = 0;
+        if (amtTag.isNotEmpty && amtTag.length >= 2) {
+          msats = int.tryParse(amtTag[1].toString()) ?? 0;
+        } else {
+          msats = int.tryParse((evt['amount'] ?? '0').toString()) ?? 0;
+        }
+        sats = (msats / 1000).round();
+        content = sats > 0 ? 'zapped \$sats sats' : 'zapped you';
+      }
+
+      if (t == null) return;
+
+      final item = NotificationItem(
+        type: t,
+        id: id,
+        fromPubkey: pk,
+        fromName: name,
+        fromAvatar: avatar,
+        relatedEventId: related,
+        content: content,
+        createdAt: created,
+        sats: sats,
+      );
+      _byId[id] = item;
+
+      final list = _byId.values.toList()
+        ..sort((a,b) => b.createdAt.compareTo(a.createdAt));
+      _ctrl.add(list);
+    });
+  }
+
+  Future<void> stop() async { await _sub?.cancel(); _sub = null; }
+  Future<void> dispose() async { await stop(); await _ctrl.close(); }
+}

--- a/lib/services/settings/settings_service.dart
+++ b/lib/services/settings/settings_service.dart
@@ -115,3 +115,9 @@ extension SignerPreference on SettingsService {
   String signerPref() => prefs.getString(_kSignerPref) ?? 'local';
   Future<void> setSignerPref(String v) => prefs.setString(_kSignerPref, v);
 }
+
+extension NotificationsSeen on SettingsService {
+  static const _kNotifSeenAt = 'notif_last_seen';
+  int notifLastSeen() => prefs.getInt(_kNotifSeenAt) ?? 0;
+  Future<void> setNotifLastSeen(int secs) => prefs.setInt(_kNotifSeenAt, secs);
+}

--- a/lib/ui/home/widgets/overlay_cluster.dart
+++ b/lib/ui/home/widgets/overlay_cluster.dart
@@ -19,6 +19,8 @@ class OverlayCluster extends StatelessWidget {
     required this.onShareTap,
     this.showInstall = false,
     this.onInstallTap,
+    this.onNotificationsTap,
+    this.unreadCount = 0,
   });
   final VoidCallback onCreateTap;
   final VoidCallback onLikeTap;
@@ -36,6 +38,8 @@ class OverlayCluster extends StatelessWidget {
   final VoidCallback onShareTap;
   final bool showInstall;
   final VoidCallback? onInstallTap;
+  final VoidCallback? onNotificationsTap;
+  final int unreadCount;
 
   @override
   Widget build(BuildContext context) {
@@ -67,9 +71,37 @@ class OverlayCluster extends StatelessWidget {
               ),
             ),
           ),
-          // Top-right search
+          // Top-right notifications and search
           Positioned(
             right: 12,
+            top: 8,
+            child: Stack(
+              clipBehavior: Clip.none,
+              children: [
+                IconButton(
+                  icon: const Icon(Icons.notifications),
+                  onPressed: onNotificationsTap,
+                ),
+                if (unreadCount > 0)
+                  Positioned(
+                    right: 4,
+                    top: 4,
+                    child: Container(
+                      padding:
+                          const EdgeInsets.symmetric(horizontal: 6, vertical: 2),
+                      decoration: BoxDecoration(
+                        color: Colors.redAccent,
+                        borderRadius: BorderRadius.circular(12),
+                      ),
+                      child: Text('$unreadCount',
+                          style: const TextStyle(fontSize: 10)),
+                    ),
+                  ),
+              ],
+            ),
+          ),
+          Positioned(
+            right: 12 + 40,
             top: 8,
             child: IconButton(
               icon: const Icon(Icons.search),

--- a/lib/ui/sheets/notifications_sheet.dart
+++ b/lib/ui/sheets/notifications_sheet.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import '../../core/di/locator.dart';
+import '../../data/repos/notifications_repository.dart';
+import '../../data/models/notification.dart';
+import '../../services/settings/settings_service.dart';
+
+class NotificationsSheet extends StatefulWidget {
+  const NotificationsSheet({super.key});
+  @override
+  State<NotificationsSheet> createState() => _NotificationsSheetState();
+}
+
+class _NotificationsSheetState extends State<NotificationsSheet> {
+  List<NotificationItem> _items = const [];
+  @override
+  void initState() {
+    super.initState();
+    Locator.I.get<NotificationsRepository>().stream().listen((list) {
+      if (mounted) setState(() => _items = list);
+    });
+    // Mark read on open
+    final nowSecs = DateTime.now().millisecondsSinceEpoch ~/ 1000;
+    Locator.I.get<SettingsService>().setNotifLastSeen(nowSecs);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              height: 4,
+              width: 36,
+              margin: const EdgeInsets.only(bottom: 12),
+              decoration: BoxDecoration(
+                color: Colors.white24,
+                borderRadius: BorderRadius.circular(2),
+              ),
+            ),
+            const Text('Notifications',
+                style: TextStyle(fontWeight: FontWeight.bold)),
+            const SizedBox(height: 8),
+            Expanded(
+              child: ListView.builder(
+                itemCount: _items.length,
+                itemBuilder: (_, i) {
+                  final n = _items[i];
+                  final lead = CircleAvatar(
+                    backgroundImage: n.fromAvatar.isNotEmpty
+                        ? NetworkImage(n.fromAvatar)
+                        : null,
+                    child: n.fromAvatar.isEmpty
+                        ? Text(n.fromName.substring(0, 1))
+                        : null,
+                  );
+                  final title = switch (n.type) {
+                    NotificationType.reply => '${n.fromName} replied',
+                    NotificationType.like => '${n.fromName} liked',
+                    NotificationType.repost => '${n.fromName} reposted',
+                    NotificationType.zap => '${n.fromName} ${n.content}',
+                  };
+                  final sub =
+                      n.type == NotificationType.reply ? n.content : '';
+                  return ListTile(
+                    dense: true,
+                    leading: lead,
+                    title: Text(title),
+                    subtitle: sub.isEmpty
+                        ? null
+                        : Text(
+                            sub,
+                            maxLines: 2,
+                            overflow: TextOverflow.ellipsis,
+                          ),
+                    onTap: () {
+                      // Future: deep link into the post using relatedEventId.
+                      Navigator.of(context).maybePop();
+                    },
+                  );
+                },
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/test/notifs/parse_map_test.dart
+++ b/test/notifs/parse_map_test.dart
@@ -1,0 +1,66 @@
+import 'dart:async';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_video/data/repos/notifications_repository.dart';
+import 'package:nostr_video/services/nostr/relay_service.dart';
+import 'package:nostr_video/services/keys/signer.dart';
+import 'package:nostr_video/services/nostr/metadata_service.dart';
+
+class _RelayFake implements RelayService {
+  final _c = StreamController<Map<String, dynamic>>.broadcast();
+  @override
+  Stream<Map<String, dynamic>> get events => _c.stream;
+  @override
+  Future<String> subscribe(List<Map<String, dynamic>> f, {String? subId}) async => 's';
+  @override
+  Future<void> close(String subId) async {}
+  @override
+  Future<void> init(List<String> relays) async {}
+  @override
+  Future<String> publishEvent(Map<String, dynamic> e) async => 'id';
+  @override
+  Future<void> like({required String eventId}) async {}
+  @override
+  Future<void> reply({required String parentId, required String content, String? parentPubkey, String? rootId, String? rootPubkey}) async {}
+  @override
+  Future<void> repost({required String eventId, String? originalJson}) async {}
+  @override
+  Future<void> zapRequest({required String eventId, required int millisats}) async {}
+  @override
+  Future<Map<String, dynamic>> buildZapRequest({required String recipientPubkey, required String eventId, String content = '', List<String>? relays}) async => {};
+  @override
+  Future<String?> signAndPublish({required int kind, required String content, required List<List<String>> tags}) async => 'id';
+  @override
+  Stream<List<dynamic>> subscribeFeed({required List<String> authors, String? hashtag}) => const Stream.empty();
+  @override
+  Future<void> resetConnections(List<String> urls) async {}
+  void emit(Map<String,dynamic> e) => _c.add(e);
+}
+
+class _SignerFake implements Signer {
+  @override
+  Future<String?> getPubkey() async => '02'+'a'*66;
+  @override
+  Future<Map<String, dynamic>?> sign(int kind, String content, List<List<String>> tags) async => {};
+}
+
+class _MetaMem implements MetadataService {
+  final _m = <String, AuthorMeta>{};
+  @override
+  AuthorMeta? get(String pubkey) => _m[pubkey];
+  @override
+  Stream<AuthorMeta> get stream => const Stream.empty();
+  @override
+  void handleEvent(Map<String, dynamic> evt) {}
+}
+
+void main() async {
+  test('maps basic kinds to notifications', () async {
+    final r = _RelayFake();
+    final repo = NotificationsRepository(r, _SignerFake(), _MetaMem());
+    await repo.start();
+    r.emit({'id':'x1','kind':7,'pubkey':'p','created_at':10,'tags':[['p','me'],['e','post1']]});
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+    final list = await repo.stream().firstWhere((l) => l.isNotEmpty);
+    expect(list.first.type.name, 'like');
+  });
+}

--- a/test/ui/notifications_sheet_smoke_test.dart
+++ b/test/ui/notifications_sheet_smoke_test.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:nostr_video/ui/sheets/notifications_sheet.dart';
+
+void main() {
+  testWidgets('sheet renders', (tester) async {
+    await tester.pumpWidget(const MaterialApp(home: Scaffold(body: NotificationsSheet())));
+    expect(find.textContaining('Notifications'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- add `NotificationItem` model and repository to stream replies, likes, reposts and zaps tagged with your pubkey
- show notifications sheet and bell badge with unread count
- persist last seen notifications timestamp in settings

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_689fb697f7d08331898ec50f4ffaae57