### PR TITLE
Persist notifications locally, add per-type filters, and make unread badge deterministic

### DIFF
--- a/lib/notifications/notification_models.dart
+++ b/lib/notifications/notification_models.dart
@@ -1,0 +1,43 @@
+import 'package:equatable/equatable.dart';
+
+/// Supported notification categories.
+enum NotificationType { reply, like, repost, zap, mention }
+
+/// Representation of a notification within the app.
+class AppNotification extends Equatable {
+  const AppNotification({
+    required this.id,
+    required this.type,
+    required this.fromPubkey,
+    this.fromName,
+    this.noteId,
+    this.content,
+    required this.createdAt,
+    this.read = false,
+  });
+
+  final String id;
+  final NotificationType type;
+  final String fromPubkey;
+  final String? fromName;
+  final String? noteId;
+  final String? content;
+  final DateTime createdAt;
+  final bool read;
+
+  AppNotification copyWith({bool? read}) {
+    return AppNotification(
+      id: id,
+      type: type,
+      fromPubkey: fromPubkey,
+      fromName: fromName,
+      noteId: noteId,
+      content: content,
+      createdAt: createdAt,
+      read: read ?? this.read,
+    );
+  }
+
+  @override
+  List<Object?> get props => [id, type, fromPubkey, fromName, noteId, content, createdAt, read];
+}

--- a/lib/notifications/notifications_controller.dart
+++ b/lib/notifications/notifications_controller.dart
@@ -1,0 +1,68 @@
+import 'notifications_store.dart';
+import 'notifications_prefs.dart';
+import 'notification_models.dart';
+import 'notifications_service.dart';
+
+/// Coordinates fetching, persistence and filtering of notifications.
+class NotificationsController {
+  NotificationsController(this.service, this.store);
+
+  final NotificationsService service;
+  final NotificationsStore store;
+
+  int _unread = 0;
+  List<AppNotification> _items = const [];
+
+  int get unread => _unread;
+  List<AppNotification> get items => _items;
+
+  bool _f(String key, bool d) => store.getPref(key, d);
+
+  /// Initializes the controller, loading any persisted notifications and
+  /// subscribing to live updates from [service].
+  Future<void> attach() async {
+    await store.init();
+    // Load persisted first
+    _applyAndCount(store.all());
+    // Live updates
+    service.start();
+    service.stream.listen((list) async {
+      for (final n in list) {
+        await store.upsert(n);
+      }
+      _applyAndCount(store.all());
+    });
+  }
+
+  void _applyAndCount(List<AppNotification> src) {
+    // Filter visibility
+    final keep = src.where((n) {
+      return switch (n.type) {
+        NotificationType.reply => _f(NotifPrefsKeys.includeReply, true),
+        NotificationType.like => _f(NotifPrefsKeys.includeLike, true),
+        NotificationType.repost => _f(NotifPrefsKeys.includeRepost, true),
+        NotificationType.zap => _f(NotifPrefsKeys.includeZap, true),
+        NotificationType.mention => _f(NotifPrefsKeys.includeMention, true),
+      };
+    }).toList();
+
+    // Count badge types and unread
+    final countable = keep.where((n) {
+      return !n.read && switch (n.type) {
+        NotificationType.reply => _f(NotifPrefsKeys.badgeReply, true),
+        NotificationType.like => _f(NotifPrefsKeys.badgeLike, true),
+        NotificationType.repost => _f(NotifPrefsKeys.badgeRepost, true),
+        NotificationType.zap => _f(NotifPrefsKeys.badgeZap, true),
+        NotificationType.mention => _f(NotifPrefsKeys.badgeMention, true),
+      };
+    });
+
+    _items = keep;
+    _unread = countable.length;
+  }
+
+  Future<void> markAllRead() async {
+    await store.markAllRead();
+    _applyAndCount(store.all());
+  }
+}

--- a/lib/notifications/notifications_prefs.dart
+++ b/lib/notifications/notifications_prefs.dart
@@ -1,0 +1,14 @@
+/// Keys used for notification preference storage.
+class NotifPrefsKeys {
+  static const includeReply = 'pref_include_reply';
+  static const includeLike = 'pref_include_like';
+  static const includeRepost = 'pref_include_repost';
+  static const includeZap = 'pref_include_zap';
+  static const includeMention = 'pref_include_mention';
+  // Which types count toward badge:
+  static const badgeReply = 'pref_badge_reply';
+  static const badgeLike = 'pref_badge_like';
+  static const badgeRepost = 'pref_badge_repost';
+  static const badgeZap = 'pref_badge_zap';
+  static const badgeMention = 'pref_badge_mention';
+}

--- a/lib/notifications/notifications_service.dart
+++ b/lib/notifications/notifications_service.dart
@@ -1,0 +1,34 @@
+import 'dart:async';
+
+import 'notification_models.dart';
+
+/// Simple interface representing a client capable of sending and receiving
+/// messages from a relay.
+abstract class INostrClient {
+  void send(String message);
+  Stream<String> get messages;
+  Future<void> close();
+}
+
+/// Base class for fetching notifications from relays.
+class NotificationsService {
+  NotificationsService({required this.client, required this.myPubkey});
+
+  final INostrClient client;
+  final String myPubkey;
+
+  final _ctrl = StreamController<List<AppNotification>>.broadcast();
+  Stream<List<AppNotification>> get stream => _ctrl.stream;
+
+  /// Starts fetching notifications. Subclasses may override to implement
+  /// concrete behaviour. The base implementation does nothing.
+  void start() {}
+
+  /// Adds a batch of notifications to listeners.
+  void emit(List<AppNotification> items) => _ctrl.add(items);
+
+  Future<void> dispose() async {
+    await client.close();
+    await _ctrl.close();
+  }
+}

--- a/lib/notifications/notifications_store.dart
+++ b/lib/notifications/notifications_store.dart
@@ -1,0 +1,62 @@
+import 'package:hive/hive.dart';
+
+import 'notification_models.dart';
+
+/// Persistence layer for notifications and their preferences.
+class NotificationsStore {
+  static const _boxNotifs = 'notifs';
+  static const _boxPrefs = 'notif_prefs';
+
+  late Box<Map> _bNotifs;
+  late Box _bPrefs;
+
+  /// Opens the underlying Hive boxes.
+  Future<void> init() async {
+    _bNotifs = await Hive.openBox<Map>(_boxNotifs);
+    _bPrefs = await Hive.openBox(_boxPrefs);
+  }
+
+  /// Inserts or updates a notification.
+  Future<void> upsert(AppNotification n) async {
+    await _bNotifs.put(n.id, {
+      'id': n.id,
+      'type': n.type.name,
+      'fromPubkey': n.fromPubkey,
+      'fromName': n.fromName,
+      'noteId': n.noteId,
+      'content': n.content,
+      'createdAt': n.createdAt.millisecondsSinceEpoch,
+      'read': n.read,
+    });
+  }
+
+  /// Returns all notifications sorted by newest first.
+  List<AppNotification> all() {
+    return _bNotifs.values.map((m) {
+      return AppNotification(
+        id: m['id'] as String,
+        type: NotificationType.values.firstWhere((t) => t.name == m['type']),
+        fromPubkey: m['fromPubkey'] as String,
+        fromName: m['fromName'] as String?,
+        noteId: m['noteId'] as String?,
+        content: m['content'] as String?,
+        createdAt: DateTime.fromMillisecondsSinceEpoch(m['createdAt'] as int),
+        read: m['read'] as bool? ?? false,
+      );
+    }).toList()
+      ..sort((a, b) => b.createdAt.compareTo(a.createdAt));
+  }
+
+  /// Marks every stored notification as read.
+  Future<void> markAllRead() async {
+    for (final k in _bNotifs.keys) {
+      final m = Map<String, dynamic>.from(_bNotifs.get(k) as Map);
+      m['read'] = true;
+      await _bNotifs.put(k, m);
+    }
+  }
+
+  // Prefs
+  bool getPref(String key, bool def) => (_bPrefs.get(key) as bool?) ?? def;
+  Future<void> setPref(String key, bool v) => _bPrefs.put(key, v);
+}

--- a/lib/ui/design/tokens.dart
+++ b/lib/ui/design/tokens.dart
@@ -1,0 +1,5 @@
+/// Basic spacing tokens used across the UI.
+class T {
+  static const double s16 = 16.0;
+  static const double s24 = 24.0;
+}

--- a/lib/ui/home/widgets/notifications_settings_sheet.dart
+++ b/lib/ui/home/widgets/notifications_settings_sheet.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+import '../../../notifications/notifications_prefs.dart';
+import '../../../notifications/notifications_store.dart';
+import '../../design/tokens.dart';
+
+/// Bottom sheet allowing users to toggle notification visibility and badge
+/// behaviour.
+class NotificationsSettingsSheet extends StatefulWidget {
+  const NotificationsSettingsSheet({super.key, required this.store});
+
+  final NotificationsStore store;
+
+  @override
+  State<NotificationsSettingsSheet> createState() => _NSSState();
+}
+
+class _NSSState extends State<NotificationsSettingsSheet> {
+  bool _get(String k, bool d) => widget.store.getPref(k, d);
+  Future<void> _set(String k, bool v) async {
+    await widget.store.setPref(k, v);
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: ListView(
+        padding: const EdgeInsets.all(T.s16),
+        children: [
+          const Text('Notifications',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600)),
+          const SizedBox(height: T.s16),
+          _tile('Show replies', NotifPrefsKeys.includeReply),
+          _tile('Show likes', NotifPrefsKeys.includeLike),
+          _tile('Show reposts', NotifPrefsKeys.includeRepost),
+          _tile('Show zaps', NotifPrefsKeys.includeZap),
+          _tile('Show mentions', NotifPrefsKeys.includeMention),
+          const Divider(height: T.s24 * 2),
+          const Text('Count in badge', style: TextStyle(fontSize: 16)),
+          _tile('Replies in badge', NotifPrefsKeys.badgeReply),
+          _tile('Likes in badge', NotifPrefsKeys.badgeLike),
+          _tile('Reposts in badge', NotifPrefsKeys.badgeRepost),
+          _tile('Zaps in badge', NotifPrefsKeys.badgeZap),
+          _tile('Mentions in badge', NotifPrefsKeys.badgeMention),
+        ],
+      ),
+    );
+  }
+
+  Widget _tile(String label, String key) {
+    final v = _get(key, true);
+    return SwitchListTile(
+      title: Text(label),
+      value: v,
+      onChanged: (nv) => _set(key, nv),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,8 +15,8 @@ dependencies:
   dio: ^5.4.0
   image_picker: ^1.0.7
   file_picker: ^8.0.0
-  hive: any
-  hive_flutter: any
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
   shared_preferences: any
   collection: any
   equatable: any
@@ -35,7 +35,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mocktail: any
-  build_runner: any
+  hive_generator: ^2.0.1
+  build_runner: ^2.4.8
   flutter_lints: any
   video_player_platform_interface: any
   network_image_mock: any
@@ -43,3 +44,5 @@ dev_dependencies:
 
 flutter:
   uses-material-design: true
+  assets:
+    - assets/icons/

--- a/test/notifications/persistence_and_filters_test.dart
+++ b/test/notifications/persistence_and_filters_test.dart
@@ -1,5 +1,7 @@
+import 'dart:io';
+
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hive_flutter/hive_flutter.dart';
+import 'package:hive/hive.dart';
 import 'package:nostr_video/notifications/notification_models.dart';
 import 'package:nostr_video/notifications/notifications_store.dart';
 import 'package:nostr_video/notifications/notifications_controller.dart';
@@ -22,7 +24,8 @@ class _NoopClient implements INostrClient {
 
 void main() {
   test('unread respects filters and persists', () async {
-    await Hive.initFlutter();
+    final tempDir = await Directory.systemTemp.createTemp();
+    Hive.init(tempDir.path);
     final store = NotificationsStore();
     await store.init();
     final svc = _FakeSvc();
@@ -52,5 +55,8 @@ void main() {
     // Recalc
     await ctrl.markAllRead(); // mark as read then no unread
     expect(ctrl.unread, 0);
+
+    await Hive.close();
+    await tempDir.delete(recursive: true);
   });
 }

--- a/test/notifications/persistence_and_filters_test.dart
+++ b/test/notifications/persistence_and_filters_test.dart
@@ -1,5 +1,4 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:hive/hive.dart';
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:nostr_video/notifications/notification_models.dart';
 import 'package:nostr_video/notifications/notifications_store.dart';

--- a/test/notifications/persistence_and_filters_test.dart
+++ b/test/notifications/persistence_and_filters_test.dart
@@ -1,0 +1,57 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:nostr_video/notifications/notification_models.dart';
+import 'package:nostr_video/notifications/notifications_store.dart';
+import 'package:nostr_video/notifications/notifications_controller.dart';
+import 'package:nostr_video/notifications/notifications_service.dart';
+
+class _FakeSvc extends NotificationsService {
+  _FakeSvc() : super(client: _NoopClient(), myPubkey: 'me');
+  @override
+  void start() {} // no timers
+}
+
+class _NoopClient implements INostrClient {
+  @override
+  void send(String _) {}
+  @override
+  Stream<String> get messages => const Stream.empty();
+  @override
+  Future<void> close() async {}
+}
+
+void main() {
+  test('unread respects filters and persists', () async {
+    await Hive.initFlutter();
+    final store = NotificationsStore();
+    await store.init();
+    final svc = _FakeSvc();
+    final ctrl = NotificationsController(svc, store);
+
+    // Seed two notifs
+    await store.upsert(AppNotification(
+      id: '1',
+      type: NotificationType.like,
+      fromPubkey: 'a',
+      createdAt: DateTime.now(),
+    ));
+    await store.upsert(AppNotification(
+      id: '2',
+      type: NotificationType.reply,
+      fromPubkey: 'b',
+      createdAt: DateTime.now(),
+    ));
+
+    await ctrl.attach();
+    expect(ctrl.unread, 2);
+
+    // Exclude likes from badge:
+    await store.setPref('pref_badge_like', false);
+    await store.setPref('pref_badge_reply', true);
+    await Future<void>.delayed(const Duration(milliseconds: 1));
+    // Recalc
+    await ctrl.markAllRead(); // mark as read then no unread
+    expect(ctrl.unread, 0);
+  });
+}


### PR DESCRIPTION
## Summary
- add Hive-backed notification store with preference flags
- filter notifications and badge counts in controller
- expose settings sheet for per-type toggles
- test persistence and unread badge logic

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter packages pub run build_runner build` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `flutter run -d chrome` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fc7bb5f188331ac6e40737f2ce4a8