### PR TITLE
feat: add web push support for Flutter PWA

### DIFF
--- a/lib/config/push_config.dart
+++ b/lib/config/push_config.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/foundation.dart';
+
+/// Inject your own values at build time or edit here.
+class PushConfig {
+  /// Base64URL VAPID public key (no padding). Example-only placeholder.
+  static const String vapidPublicKey = String.fromEnvironment(
+    'VAPID_PUBLIC',
+    defaultValue: 'BOPo8e1v...your_public_key_here...'
+  );
+
+  /// HTTPS endpoint that accepts a JSON WebPush subscription (see tools/webpush-server).
+  static const String subscriptionEndpoint = String.fromEnvironment(
+    'PUSH_SUBSCRIBE_URL',
+    defaultValue: 'https://your.push.endpoint.example/subscribe'
+  );
+
+  static bool get isWeb => kIsWeb;
+}

--- a/lib/ui/home/widgets/notifications_settings_sheet.dart
+++ b/lib/ui/home/widgets/notifications_settings_sheet.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import '../../../notifications/notifications_prefs.dart';
 import '../../../notifications/notifications_store.dart';
 import '../../design/tokens.dart';
+import '../../../web_push/web_push.dart';
 
 /// Bottom sheet allowing users to toggle notification visibility and badge
 /// behaviour.
@@ -31,6 +32,20 @@ class _NSSState extends State<NotificationsSettingsSheet> {
           const Text('Notifications',
               style: TextStyle(fontSize: 18, fontWeight: FontWeight.w600)),
           const SizedBox(height: T.s16),
+          ListTile(
+            title: const Text('Enable Web Push (PWA)'),
+            subtitle: const Text('Receive notifications when the app is closed'),
+            trailing: ElevatedButton(
+              onPressed: () async {
+                final ok = await WebPushManager.enable();
+                if (!context.mounted) return;
+                final snack = SnackBar(content: Text(ok ? 'Web Push enabled' : 'Web Push failed'));
+                ScaffoldMessenger.of(context).showSnackBar(snack);
+                setState((){}); // reflect any UI change you want
+              },
+              child: const Text('Enable'),
+            ),
+          ),
           _tile('Show replies', NotifPrefsKeys.includeReply),
           _tile('Show likes', NotifPrefsKeys.includeLike),
           _tile('Show reposts', NotifPrefsKeys.includeRepost),

--- a/lib/web_push/base64_url.dart
+++ b/lib/web_push/base64_url.dart
@@ -1,0 +1,11 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+/// Decode a base64url string (no padding) into bytes.
+Uint8List base64UrlToBytes(String s) {
+  var b64 = s.replaceAll('-', '+').replaceAll('_', '/');
+  while (b64.length % 4 != 0) {
+    b64 += '=';
+  }
+  return Uint8List.fromList(base64Decode(b64));
+}

--- a/lib/web_push/web_push.dart
+++ b/lib/web_push/web_push.dart
@@ -6,12 +6,7 @@ import 'dart:js_util' as js_util;
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import '../config/push_config.dart';
-
-Uint8List base64UrlToBytes(String s) {
-  var b64 = s.replaceAll('-', '+').replaceAll('_', '/');
-  while (b64.length % 4 != 0) { b64 += '='; }
-  return Uint8List.fromList(base64Decode(b64));
-}
+import 'base64_url.dart';
 
 class WebPushManager {
   static bool get supported =>

--- a/lib/web_push/web_push.dart
+++ b/lib/web_push/web_push.dart
@@ -1,0 +1,56 @@
+import 'dart:convert';
+import 'dart:html' as html;
+import 'dart:typed_data';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+import '../config/push_config.dart';
+
+Uint8List base64UrlToBytes(String s) {
+  var b64 = s.replaceAll('-', '+').replaceAll('_', '/');
+  while (b64.length % 4 != 0) { b64 += '='; }
+  return Uint8List.fromList(base64Decode(b64));
+}
+
+class WebPushManager {
+  static bool get supported =>
+      kIsWeb &&
+      html.window.navigator.serviceWorker != null &&
+      html.Notification.supported;
+
+  /// Registers SW, asks permission, and subscribes with VAPID key.
+  static Future<bool> enable() async {
+    if (!supported || !PushConfig.isWeb) return false;
+
+    // Register our standalone push SW (separate from flutter_service_worker.js)
+    final reg = await html.window.navigator.serviceWorker!.register('sw_push.js');
+    await reg.update();
+
+    // Permission
+    final permission = await html.Notification.requestPermission();
+    if (permission != 'granted') return false;
+
+    // Subscribe
+    final sub = await reg.pushManager.subscribe(html.PushSubscriptionOptions(
+      userVisibleOnly: true,
+      applicationServerKey: base64UrlToBytes(PushConfig.vapidPublicKey),
+    ));
+
+    // Send subscription to server
+    final body = sub.toJson();
+    final resp = await http.post(
+      Uri.parse(PushConfig.subscriptionEndpoint),
+      headers: {'content-type': 'application/json'},
+      body: jsonEncode(body),
+    );
+    return resp.statusCode >= 200 && resp.statusCode < 300;
+  }
+
+  static Future<void> disable() async {
+    if (!supported) return;
+    final regs = await html.window.navigator.serviceWorker!.getRegistrations();
+    for (final r in regs) {
+      final sub = await r.pushManager.getSubscription();
+      await sub?.unsubscribe(); // server clean-up is optional/manual
+    }
+  }
+}

--- a/lib/web_push/web_push.dart
+++ b/lib/web_push/web_push.dart
@@ -1,6 +1,8 @@
+// ignore_for_file: deprecated_member_use, avoid_web_libraries_in_flutter
+
 import 'dart:convert';
 import 'dart:html' as html;
-import 'dart:typed_data';
+import 'dart:js_util' as js_util;
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;
 import '../config/push_config.dart';
@@ -30,13 +32,14 @@ class WebPushManager {
     if (permission != 'granted') return false;
 
     // Subscribe
-    final sub = await reg.pushManager.subscribe(html.PushSubscriptionOptions(
-      userVisibleOnly: true,
-      applicationServerKey: base64UrlToBytes(PushConfig.vapidPublicKey),
-    ));
+    final sub = await reg.pushManager?.subscribe({
+      'userVisibleOnly': true,
+      'applicationServerKey': base64UrlToBytes(PushConfig.vapidPublicKey),
+    });
+    if (sub == null) return false;
 
     // Send subscription to server
-    final body = sub.toJson();
+    final body = js_util.callMethod(sub, 'toJSON', []);
     final resp = await http.post(
       Uri.parse(PushConfig.subscriptionEndpoint),
       headers: {'content-type': 'application/json'},

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -30,6 +30,7 @@ dependencies:
   bech32: ^0.2.2
   qr_flutter: ^4.1.0
   share_plus: ^10.0.0
+  http: ^1.2.2
 
 dev_dependencies:
   flutter_test:

--- a/test/web_push/base64url_decode_test.dart
+++ b/test/web_push/base64url_decode_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:nostr_video/web_push/web_push.dart';
+import 'package:nostr_video/web_push/base64_url.dart';
 
 void main() {
   test('base64url decode pads correctly', () {

--- a/test/web_push/base64url_decode_test.dart
+++ b/test/web_push/base64url_decode_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_video/web_push/web_push.dart';
+
+void main() {
+  test('base64url decode pads correctly', () {
+    // "test" -> dGVzdA==
+    // url-safe without padding:
+    final bytes = base64UrlToBytes('dGVzdA');
+    expect(bytes.length, 4);
+  });
+}

--- a/tools/webpush-server/README.md
+++ b/tools/webpush-server/README.md
@@ -1,0 +1,17 @@
+# Minimal Web Push server (example)
+- Use **Cloudflare Worker** or **Node** with `web-push` to store subscriptions and send pushes.
+- Keep it privacy-first: store only the subscription JSON; no user PII.
+
+## Generate VAPID keys
+```bash
+npx web-push generate-vapid-keys
+```
+
+Record:
+
+* Public Key  -> used by app (PushConfig.vapidPublicKey)
+* Private Key -> kept on the server
+
+## Example: Cloudflare Worker (TypeScript)
+
+See `worker.ts`. Deploy to a HTTPS URL and set it as `PUSH_SUBSCRIBE_URL`.

--- a/tools/webpush-server/worker.ts
+++ b/tools/webpush-server/worker.ts
@@ -1,0 +1,28 @@
+/* pseudo-implementation outline */
+import { Router } from 'itty-router'
+import { Env, sendPush } from './wp'; // your helper using web-push-like lib
+
+const router = Router();
+router.post('/subscribe', async (req: Request, env: Env) => {
+const sub = await req.json();
+// persist in KV: key=sub.endpoint
+await env.SUBS.put(sub.endpoint, JSON.stringify(sub));
+return new Response('ok');
+});
+
+router.post('/send', async (req: Request, env: Env) => {
+const { title, body, url } = await req.json();
+const list = await env.SUBS.list();
+let ok = 0;
+for (const k of list.keys) {
+const raw = await env.SUBS.get(k.name);
+if (!raw) continue;
+const sub = JSON.parse(raw);
+const payload = JSON.stringify({ title, body, url });
+const r = await sendPush(sub, payload, env); // uses VAPID private key
+if (r) ok++;
+}
+return new Response(JSON.stringify({ sent: ok }), { headers: { 'content-type': 'application/json' }});
+});
+
+export default { fetch: (req: Request, env: Env, ctx: ExecutionContext) => router.handle(req, env, ctx) }

--- a/web/index.html
+++ b/web/index.html
@@ -10,6 +10,7 @@
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <script defer src="install_prompt.js"></script>
+    <!-- sw_push.js is our standalone push service worker registered from Dart -->
     <!-- Flutter injects main.dart.js and registers flutter_service_worker.js in release builds -->
   </head>
   <body>

--- a/web/sw_push.js
+++ b/web/sw_push.js
@@ -1,0 +1,28 @@
+/* Standalone SW for web push (do not modify flutter_service_worker.js) */
+self.addEventListener('install', () => self.skipWaiting());
+self.addEventListener('activate', e => e.waitUntil(self.clients.claim()));
+
+self.addEventListener('push', event => {
+  let payload = {};
+  try { payload = event.data ? event.data.json() : {}; } catch (_) {}
+  const title = payload.title || 'ShortLived';
+  const options = {
+    body: payload.body || '',
+    icon: payload.icon || 'icons/Icon-192.png',
+    badge: payload.badge || 'icons/Icon-192.png',
+    data: { url: payload.url || '/' },
+    tag: payload.tag || 'shortlived',
+    renotify: !!payload.renotify,
+  };
+  event.waitUntil(self.registration.showNotification(title, options));
+});
+
+self.addEventListener('notificationclick', event => {
+  event.notification.close();
+  const url = (event.notification.data && event.notification.data.url) || '/';
+  event.waitUntil((async () => {
+    const all = await clients.matchAll({ type: 'window', includeUncontrolled: true });
+    for (const c of all) { if ('focus' in c) { c.focus(); if (url) c.navigate(url); return; } }
+    if (clients.openWindow) await clients.openWindow(url);
+  })());
+});


### PR DESCRIPTION
## Summary
- add service worker and push configuration for web push notifications
- implement WebPushManager with enable/disable flows
- expose Web Push toggle in notification settings
- document example server for storing and sending pushes

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test test/web_push/base64url_decode_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fd1fbc76c83319a5eeb5a668cbd17