### PR TITLE
Prevent white screen on Flutter Web by adding localhost bootstrap, making PWA script non-blocking, and unregistering stale service workers in debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,14 @@ flutter run
 * docs/NIPs.md
 * docs/PRIVACY.md
 * docs/ADR/
+
+## Flutter Web white screen (debug)
+If you see a blank page on `flutter run -d chrome`:
+
+1. This repo unregisters service workers in debug web automatically.
+2. `web/index.html` contains a localhost bootstrap via `flutter.js` to start the engine when injection fails.
+3. `web/install_prompt.js` is a no-throw stub and cannot block startup.
+
+If the page is still blank, open DevTools → Console and copy the first error. Common issues:
+- Missing vector icon assets (`assets/icons/*.svg` not compiled to `.svg.vec`).
+- A custom script added outside of this PR that throws early.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,10 +1,40 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'core/app_router.dart';
 
-void main() {
-  runApp(MaterialApp(
-    navigatorKey: AppRouter.navKey,
-    onGenerateRoute: AppRouter.onGenerate,
-    home: const Placeholder(),
-  ));
+// Conditional import: on web use the real implementation, elsewhere the stub.
+import 'util/sw_debug_stub.dart'
+  if (dart.library.html) 'util/sw_debug_web.dart';
+
+Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+
+  // Print Flutter framework errors to the browser console.
+  FlutterError.onError = (FlutterErrorDetails details) {
+    FlutterError.dumpErrorToConsole(details);
+  };
+
+  // In debug on web, unregister any stale service workers and caches.
+  assert(() {
+    if (kIsWeb) {
+      // Fire-and-forget; we don't await to avoid slowing startup.
+      // ignore: unawaited_futures
+      killServiceWorkersInDebug();
+    }
+    return true;
+  }());
+
+  runZonedGuarded(
+    () => runApp(MaterialApp(
+      navigatorKey: AppRouter.navKey,
+      onGenerateRoute: AppRouter.onGenerate,
+      home: const Placeholder(),
+    )),
+    (Object error, StackTrace stack) {
+      // Surface uncaught errors in console for web debug.
+      // ignore: avoid_print
+      print('Uncaught zone error: $error\n$stack');
+    },
+  );
 }

--- a/lib/util/sw_debug_stub.dart
+++ b/lib/util/sw_debug_stub.dart
@@ -1,0 +1,1 @@
+Future<void> killServiceWorkersInDebug() async {}

--- a/lib/util/sw_debug_web.dart
+++ b/lib/util/sw_debug_web.dart
@@ -1,3 +1,4 @@
+// ignore_for_file: deprecated_member_use, avoid_web_libraries_in_flutter
 import 'dart:html' as html;
 
 /// Unregister all service workers in debug web to avoid stale caches while developing.
@@ -8,9 +9,10 @@ Future<void> killServiceWorkersInDebug() async {
       await r.unregister();
     }
     // Best-effort: clear Cache Storage keys
-    final cacheKeys = await html.window.caches.keys();
+    final caches = html.window.caches;
+    final cacheKeys = caches != null ? await caches.keys() : const <String>[];
     for (final k in cacheKeys) {
-      await html.window.caches.delete(k);
+      await caches?.delete(k);
     }
   } catch (_) {
     // ignore — never block startup

--- a/lib/util/sw_debug_web.dart
+++ b/lib/util/sw_debug_web.dart
@@ -1,0 +1,18 @@
+import 'dart:html' as html;
+
+/// Unregister all service workers in debug web to avoid stale caches while developing.
+Future<void> killServiceWorkersInDebug() async {
+  try {
+    final regs = await html.window.navigator.serviceWorker?.getRegistrations() ?? const [];
+    for (final r in regs) {
+      await r.unregister();
+    }
+    // Best-effort: clear Cache Storage keys
+    final cacheKeys = await html.window.caches.keys();
+    for (final k in cacheKeys) {
+      await html.window.caches.delete(k);
+    }
+  } catch (_) {
+    // ignore — never block startup
+  }
+}

--- a/web/index.html
+++ b/web/index.html
@@ -9,11 +9,37 @@
     <link rel="apple-touch-icon" href="icons/icon-192.png">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
+
+    <!-- Safe PWA install prompt (non-blocking) -->
     <script defer src="install_prompt.js"></script>
-    <!-- sw_push.js is our standalone push service worker registered from Dart -->
-    <!-- Flutter injects main.dart.js and registers flutter_service_worker.js in release builds -->
+
+    <!-- Dev bootstrap for flutter run (no-op in release). 
+         flutter.js is added by Flutter toolchain; this call helps when injection fails in debug. -->
+    <script defer src="flutter.js"></script>
   </head>
   <body>
-    <script>/* Flutter bootstrapped here by build */</script>
+    <!-- In release builds Flutter injects main.dart.js and registers flutter_service_worker.js. -->
+    <script>
+      (function () {
+        const isLocal = location.hostname === 'localhost' || location.hostname === '127.0.0.1';
+        window.addEventListener('load', async () => {
+          // Only attempt manual bootstrap for local debug; release uses the generated loader.
+          if (!isLocal || !window._flutter || !window._flutter.loader) return;
+          try {
+            const engine = await window._flutter.loader.loadEntrypoint({
+              serviceWorker: { serviceWorkerVersion: null } // no SW in debug
+            });
+            const app = await engine.initializeEngine();
+            await app.runApp();
+          } catch (e) {
+            console.error('Flutter boot failed:', e);
+            const div = document.createElement('pre');
+            div.style.cssText = 'color:#fff;background:#000;padding:16px';
+            div.textContent = 'Flutter boot failed: ' + (e && e.message ? e.message : e);
+            document.body.appendChild(div);
+          }
+        });
+      })();
+    </script>
   </body>
 </html>

--- a/web/install_prompt.js
+++ b/web/install_prompt.js
@@ -1,16 +1,12 @@
-(function() {
-  let deferred;
-  window.addEventListener('beforeinstallprompt', (e) => {
-    e.preventDefault();
-    deferred = e;
-    window.dispatchEvent(new Event('__pwa-install-available'));
-  });
-
-  window.__pwaPrompt = async function() {
-    if (!deferred) return { ok: false, reason: 'not-available' };
-    deferred.prompt();
-    const { outcome } = await deferred.userChoice;
-    deferred = null;
-    return { ok: outcome === 'accepted', outcome };
-  };
+/* Non-blocking PWA install prompt stub for debug and release. */
+(function () {
+  try {
+    window.__pwaDeferredPrompt = null;
+    window.addEventListener('beforeinstallprompt', (e) => {
+      e.preventDefault();
+      window.__pwaDeferredPrompt = e; // call prompt() later from UI
+    });
+  } catch (_) {
+    // Never block startup
+  }
 })();


### PR DESCRIPTION
## Summary
- add manual localhost bootstrap via `flutter.js`
- replace install prompt script with non-blocking stub
- unregister service workers and caches in web debug

## Testing
- `flutter clean && flutter pub get` *(fails: command not found: flutter)*
- `flutter run -d chrome --web-renderer html` *(fails: command not found: flutter)*
- `flutter run -d chrome --web-renderer canvaskit` *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689fd9099e608331ba7d94bdb2113632