### PR TITLE
Remove Placeholder screens and mount HomePage with overlay UI and a CORS-safe demo video

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,6 +15,8 @@ jobs:
         run: flutter pub get
       - name: Flutter Analyze
         run: flutter analyze
+      - name: Guard against Placeholder widgets
+        run: bash scripts/dev/find_placeholders.sh
       - name: Flutter Test
         run: flutter test
       - name: Build web artefacts

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'core/app_router.dart';
+import 'ui/design/theme.dart';
+import 'ui/home/home_page.dart';
 
 class App extends StatelessWidget {
   const App({super.key});
@@ -9,7 +11,9 @@ class App extends StatelessWidget {
     return MaterialApp(
       navigatorKey: AppRouter.navKey,
       onGenerateRoute: AppRouter.onGenerate,
-      home: const Placeholder(),
+      debugShowCheckedModeBanner: false,
+      theme: appThemeDark,
+      home: const HomePage(),
     );
   }
 }

--- a/lib/ui/design/theme.dart
+++ b/lib/ui/design/theme.dart
@@ -1,0 +1,8 @@
+import 'package:flutter/material.dart';
+import 'tokens.dart';
+
+final ThemeData appThemeDark = ThemeData(
+  brightness: Brightness.dark,
+  scaffoldBackgroundColor: T.bg,
+  primaryColor: T.blue,
+);

--- a/lib/ui/design/tokens.dart
+++ b/lib/ui/design/tokens.dart
@@ -1,5 +1,12 @@
-/// Basic spacing tokens used across the UI.
+import 'package:flutter/material.dart';
+
+/// Basic design tokens used across the UI.
 class T {
   static const double s16 = 16.0;
   static const double s24 = 24.0;
+
+  static const double r16 = 16.0;
+
+  static const Color bg = Colors.black;
+  static const Color blue = Colors.blueAccent;
 }

--- a/lib/ui/home/home_feed_page.dart
+++ b/lib/ui/home/home_feed_page.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
-import 'widgets/video_player_view.dart';
+import 'widgets/feed_video_player_view.dart';
 import 'widgets/overlay_cluster.dart';
 import '../sheets/create_sheet.dart';
 import '../sheets/comments_sheet.dart';

--- a/lib/ui/home/home_page.dart
+++ b/lib/ui/home/home_page.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import '../design/tokens.dart';
+import '../widgets/app_icon.dart';
+import 'widgets/overlay_cluster.dart';
+import 'widgets/video_player_view.dart';
+
+/// CORS-safe demo video for web; replace with real feed when plugged in.
+const _demoVideo =
+    'https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4';
+
+class HomePage extends StatefulWidget {
+  const HomePage({super.key});
+  @override
+  State<HomePage> createState() => _HomePageState();
+}
+
+class _HomePageState extends State<HomePage> {
+  bool _overlaysVisible = true;
+  bool _muted = true;
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onLongPress: () => setState(() => _overlaysVisible = !_overlaysVisible),
+      child: Scaffold(
+        backgroundColor: T.bg,
+        body: Stack(
+          children: [
+            Positioned.fill(
+              child: VideoPlayerView(
+                url: _demoVideo,
+                autoplay: true,
+                muted: _muted,
+                fit: BoxFit.cover,
+                onReady: () {},
+              ),
+            ),
+            AnimatedOpacity(
+              opacity: _overlaysVisible ? 1 : 0,
+              duration: const Duration(milliseconds: 150),
+              child: IgnorePointer(
+                ignoring: !_overlaysVisible,
+                child: SafeArea(
+                  child: Stack(
+                    children: [
+                      Positioned(
+                        right: T.s24,
+                        top: T.s24,
+                        child: const SizedBox(
+                          width: 48,
+                          height: 48,
+                          child: Center(child: AppIcon('bell_24')),
+                        ),
+                      ),
+                      Positioned(
+                        right: T.s24,
+                        bottom: MediaQuery.of(context).size.height * 0.18,
+                        child: OverlayCluster(
+                          onCreateTap: () {},
+                          onLikeTap: () {},
+                          onCommentTap: () {},
+                          onRepostTap: () {},
+                          onQuoteTap: () {},
+                          onZapTap: () {},
+                          onProfileTap: () {},
+                          onDetailsTap: () {},
+                          onRelaysLongPress: () {},
+                          onSearchTap: () {},
+                          onSettingsTap: () {},
+                          safetyOn: true,
+                          onSafetyToggle: () {},
+                          onShareTap: () {},
+                          onNotificationsTap: () {},
+                        ),
+                      ),
+                      Positioned(
+                        left: T.s24,
+                        right: T.s24,
+                        bottom:
+                            MediaQuery.of(context).size.height * 0.22,
+                        child: Container(
+                          padding: const EdgeInsets.all(12),
+                          decoration: BoxDecoration(
+                            color: Colors.white.withOpacity(0.10),
+                            borderRadius: BorderRadius.circular(T.r16),
+                          ),
+                          child: RichText(
+                            text: TextSpan(
+                              style: Theme.of(context).textTheme.bodyMedium,
+                              children: const [
+                                TextSpan(text: 'Enjoying a sunny day '),
+                                TextSpan(
+                                    text: '#nature ',
+                                    style: TextStyle(color: T.blue)),
+                                TextSpan(
+                                    text: '#sydney ',
+                                    style: TextStyle(color: T.blue)),
+                                TextSpan(
+                                    text: '#nostr',
+                                    style: TextStyle(color: T.blue)),
+                              ],
+                            ),
+                          ),
+                        ),
+                      ),
+                      if (kIsWeb)
+                        Positioned(
+                          left: T.s24,
+                          bottom:
+                              MediaQuery.of(context).size.height * 0.28,
+                          child: ElevatedButton(
+                            onPressed: () =>
+                                setState(() => _muted = !_muted),
+                            child: Text(_muted ? 'Unmute' : 'Mute'),
+                          ),
+                        ),
+                      Positioned(
+                        left: 0,
+                        right: 0,
+                        bottom: T.s24,
+                        child: Column(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Container(
+                              width: 56,
+                              height: 56,
+                              decoration: BoxDecoration(
+                                borderRadius: BorderRadius.circular(28),
+                                border: Border.all(
+                                    color: Colors.white.withOpacity(0.85),
+                                    width: 2),
+                              ),
+                            ),
+                            const SizedBox(height: 8),
+                            const Text('Create',
+                                style: TextStyle(color: Colors.white)),
+                          ],
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/ui/home/home_page.dart
+++ b/lib/ui/home/home_page.dart
@@ -82,7 +82,7 @@ class _HomePageState extends State<HomePage> {
                         child: Container(
                           padding: const EdgeInsets.all(12),
                           decoration: BoxDecoration(
-                            color: Colors.white.withOpacity(0.10),
+                            color: Colors.white.withValues(alpha: 0.10),
                             borderRadius: BorderRadius.circular(T.r16),
                           ),
                           child: RichText(
@@ -128,7 +128,7 @@ class _HomePageState extends State<HomePage> {
                               decoration: BoxDecoration(
                                 borderRadius: BorderRadius.circular(28),
                                 border: Border.all(
-                                    color: Colors.white.withOpacity(0.85),
+                                    color: Colors.white.withValues(alpha: 0.85),
                                     width: 2),
                               ),
                             ),

--- a/lib/ui/home/widgets/feed_video_player_view.dart
+++ b/lib/ui/home/widgets/feed_video_player_view.dart
@@ -1,0 +1,179 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart' show kIsWeb;
+import 'package:video_player/video_player.dart';
+import '../../../state/feed_controller.dart';
+import '../../../data/repos/feed_repository.dart';
+import '../../../data/models/post.dart';
+import '../video_controller_pool.dart';
+import 'video_card.dart';
+import 'package:nostr_video/core/di/locator.dart';
+import '../../../core/testing/test_switches.dart';
+import '../../../services/nostr/relay_service.dart';
+import '../../../services/cache/cache_service.dart';
+import '../../../services/settings/settings_service.dart';
+import '../../../services/safety/content_safety_service.dart';
+
+class VideoPlayerView extends StatefulWidget {
+  const VideoPlayerView({super.key, required this.globalPaused});
+  final bool globalPaused; // paused by sheet or app lifecycle
+
+  @override
+  State<VideoPlayerView> createState() => _VideoPlayerViewState();
+}
+
+class _VideoPlayerViewState extends State<VideoPlayerView> with WidgetsBindingObserver {
+  late final FeedController controller;
+  final PageController pageController = PageController();
+
+  ControllerPool<VideoPlayerController>? pool;
+  Timer? _initDebounce;
+  Future<void>? _refreshing;
+
+  @override
+  void initState() {
+    super.initState();
+    WidgetsBinding.instance.addObserver(this);
+    final relay = Locator.I.get<RelayService>();
+    final cache = Locator.I.get<CacheService>();
+    controller = FeedController(RealFeedRepository(relay, cache));
+    Locator.I.put<FeedController>(controller);
+    controller.addListener(_onController);
+    controller.connect();
+
+    if (!TestSwitches.disableVideo) {
+      pool = ControllerPool<VideoPlayerController>(
+        ctor: (url) async {
+          final c = VideoPlayerController.networkUrl(Uri.parse(url));
+          await c.initialize();
+          await c.setLooping(true);
+          // Web allows autoplay only when muted.
+          await c.setVolume(kIsWeb ? 0.0 : 1.0);
+          return c;
+        },
+        dispose: (c) async {
+          await c.pause();
+          await c.dispose();
+        },
+      );
+
+      // Warm initial controllers after first data load
+      _initDebounce = Timer(const Duration(milliseconds: 100), _refreshPool);
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant VideoPlayerView oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    // Pause/resume current on global toggle
+    _refreshPool();
+  }
+
+  @override
+  void didChangeAppLifecycleState(AppLifecycleState state) {
+    // Pause on inactive/paused; resume on resumed (handled via globalPaused wireup by parent if needed)
+    if (state == AppLifecycleState.paused || state == AppLifecycleState.inactive) {
+      setState(() {}); // cause RealVideoView rebuild with isPlaying=false
+    }
+  }
+
+  void _onController() {
+    if (mounted) setState(() {});
+    _refreshPool();
+  }
+
+  Future<void> _refreshPool() {
+    if (TestSwitches.disableVideo) return Future.value();
+    final future = _doRefresh();
+    _refreshing = future;
+    return future;
+  }
+
+  Future<void> _doRefresh() async {
+    if (!mounted || TestSwitches.disableVideo || pool == null) return;
+    final posts = controller.posts;
+    if (posts.isEmpty) return;
+    final idx = controller.index;
+    final keep = <int>{idx};
+    if (idx - 1 >= 0) keep.add(idx - 1);
+    if (idx + 1 < posts.length) keep.add(idx + 1);
+
+    // Map urls for the keep set only
+    final m = <int, String>{for (final i in keep) i: posts[i].url};
+
+    await pool!.ensureFor(indexToUrl: m, keep: keep);
+
+    // Auto play/pause current based on global state is handled in RealVideoView
+    if (mounted) setState(() {});
+  }
+
+  @override
+  void dispose() {
+    _initDebounce?.cancel();
+    controller.removeListener(_onController);
+    pageController.dispose();
+    WidgetsBinding.instance.removeObserver(this);
+    _disposeAsync();
+    super.dispose();
+  }
+
+  Future<void> _disposeAsync() async {
+    await _refreshing;
+    if (!TestSwitches.disableVideo) {
+      await pool?.clear();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final posts = controller.posts;
+    if (posts.isEmpty) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    final useVideo = !TestSwitches.disableVideo && pool != null;
+    final settings = Locator.I.tryGet<SettingsService>();
+    final safety = settings == null ? null : ContentSafetyService(settings);
+    final blurEnabled = settings?.sensitiveBlurEnabled() ?? false;
+
+    return Stack(
+      fit: StackFit.expand,
+      children: [
+        PageView.builder(
+          key: const Key('feed-pageview'),
+          controller: pageController,
+          scrollDirection: Axis.vertical,
+          onPageChanged: (i) {
+            controller.onPageChanged(i);
+          },
+          itemCount: posts.length,
+          itemBuilder: (context, i) {
+            final Post p = posts[i];
+            final isCurrent = i == controller.index;
+            final isNeighbour = controller.preloadCandidates.contains(i);
+            final ctl = useVideo ? pool![i] : null;
+            final blur = blurEnabled && (safety?.isSensitive(p) ?? false);
+            return VideoCard(
+              post: p,
+              isCurrent: isCurrent,
+              isNeighbour: isNeighbour,
+              controller: ctl,
+              globalPaused: widget.globalPaused,
+              blurBySafety: blur,
+            );
+          },
+        ),
+        // Debug: show active controller count
+        Positioned(
+          right: 8,
+          top: 8,
+          child: Text(
+            useVideo ? '${pool!.size}' : '0',
+            key: const Key('active-controllers'),
+            style: const TextStyle(fontSize: 10),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/ui/home/widgets/video_player_view.dart
+++ b/lib/ui/home/widgets/video_player_view.dart
@@ -1,179 +1,32 @@
-import 'dart:async';
 import 'package:flutter/material.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
-import 'package:video_player/video_player.dart';
-import '../../../state/feed_controller.dart';
-import '../../../data/repos/feed_repository.dart';
-import '../../../data/models/post.dart';
-import '../video_controller_pool.dart';
-import 'video_card.dart';
-import 'package:nostr_video/core/di/locator.dart';
-import '../../../core/testing/test_switches.dart';
-import '../../../services/nostr/relay_service.dart';
-import '../../../services/cache/cache_service.dart';
-import '../../../services/settings/settings_service.dart';
-import '../../../services/safety/content_safety_service.dart';
+import '../../../video/video_adapter.dart';
 
-class VideoPlayerView extends StatefulWidget {
-  const VideoPlayerView({super.key, required this.globalPaused});
-  final bool globalPaused; // paused by sheet or app lifecycle
+/// Basic video player that delegates to the current [VideoAdapter].
+class VideoPlayerView extends StatelessWidget {
+  const VideoPlayerView({
+    super.key,
+    required this.url,
+    required this.autoplay,
+    required this.muted,
+    required this.fit,
+    required this.onReady,
+  });
 
-  @override
-  State<VideoPlayerView> createState() => _VideoPlayerViewState();
-}
-
-class _VideoPlayerViewState extends State<VideoPlayerView> with WidgetsBindingObserver {
-  late final FeedController controller;
-  final PageController pageController = PageController();
-
-  ControllerPool<VideoPlayerController>? pool;
-  Timer? _initDebounce;
-  Future<void>? _refreshing;
-
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addObserver(this);
-    final relay = Locator.I.get<RelayService>();
-    final cache = Locator.I.get<CacheService>();
-    controller = FeedController(RealFeedRepository(relay, cache));
-    Locator.I.put<FeedController>(controller);
-    controller.addListener(_onController);
-    controller.connect();
-
-    if (!TestSwitches.disableVideo) {
-      pool = ControllerPool<VideoPlayerController>(
-        ctor: (url) async {
-          final c = VideoPlayerController.networkUrl(Uri.parse(url));
-          await c.initialize();
-          await c.setLooping(true);
-          // Web allows autoplay only when muted.
-          await c.setVolume(kIsWeb ? 0.0 : 1.0);
-          return c;
-        },
-        dispose: (c) async {
-          await c.pause();
-          await c.dispose();
-        },
-      );
-
-      // Warm initial controllers after first data load
-      _initDebounce = Timer(const Duration(milliseconds: 100), _refreshPool);
-    }
-  }
-
-  @override
-  void didUpdateWidget(covariant VideoPlayerView oldWidget) {
-    super.didUpdateWidget(oldWidget);
-    // Pause/resume current on global toggle
-    _refreshPool();
-  }
-
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    // Pause on inactive/paused; resume on resumed (handled via globalPaused wireup by parent if needed)
-    if (state == AppLifecycleState.paused || state == AppLifecycleState.inactive) {
-      setState(() {}); // cause RealVideoView rebuild with isPlaying=false
-    }
-  }
-
-  void _onController() {
-    if (mounted) setState(() {});
-    _refreshPool();
-  }
-
-  Future<void> _refreshPool() {
-    if (TestSwitches.disableVideo) return Future.value();
-    final future = _doRefresh();
-    _refreshing = future;
-    return future;
-  }
-
-  Future<void> _doRefresh() async {
-    if (!mounted || TestSwitches.disableVideo || pool == null) return;
-    final posts = controller.posts;
-    if (posts.isEmpty) return;
-    final idx = controller.index;
-    final keep = <int>{idx};
-    if (idx - 1 >= 0) keep.add(idx - 1);
-    if (idx + 1 < posts.length) keep.add(idx + 1);
-
-    // Map urls for the keep set only
-    final m = <int, String>{for (final i in keep) i: posts[i].url};
-
-    await pool!.ensureFor(indexToUrl: m, keep: keep);
-
-    // Auto play/pause current based on global state is handled in RealVideoView
-    if (mounted) setState(() {});
-  }
-
-  @override
-  void dispose() {
-    _initDebounce?.cancel();
-    controller.removeListener(_onController);
-    pageController.dispose();
-    WidgetsBinding.instance.removeObserver(this);
-    _disposeAsync();
-    super.dispose();
-  }
-
-  Future<void> _disposeAsync() async {
-    await _refreshing;
-    if (!TestSwitches.disableVideo) {
-      await pool?.clear();
-    }
-  }
+  final String url;
+  final bool autoplay;
+  final bool muted;
+  final BoxFit fit;
+  final VideoReady onReady;
 
   @override
   Widget build(BuildContext context) {
-    final posts = controller.posts;
-    if (posts.isEmpty) {
-      return const Center(child: CircularProgressIndicator());
-    }
-
-    final useVideo = !TestSwitches.disableVideo && pool != null;
-    final settings = Locator.I.tryGet<SettingsService>();
-    final safety = settings == null ? null : ContentSafetyService(settings);
-    final blurEnabled = settings?.sensitiveBlurEnabled() ?? false;
-
-    return Stack(
-      fit: StackFit.expand,
-      children: [
-        PageView.builder(
-          key: const Key('feed-pageview'),
-          controller: pageController,
-          scrollDirection: Axis.vertical,
-          onPageChanged: (i) {
-            controller.onPageChanged(i);
-          },
-          itemCount: posts.length,
-          itemBuilder: (context, i) {
-            final Post p = posts[i];
-            final isCurrent = i == controller.index;
-            final isNeighbour = controller.preloadCandidates.contains(i);
-            final ctl = useVideo ? pool![i] : null;
-            final blur = blurEnabled && (safety?.isSensitive(p) ?? false);
-            return VideoCard(
-              post: p,
-              isCurrent: isCurrent,
-              isNeighbour: isNeighbour,
-              controller: ctl,
-              globalPaused: widget.globalPaused,
-              blurBySafety: blur,
-            );
-          },
-        ),
-        // Debug: show active controller count
-        Positioned(
-          right: 8,
-          top: 8,
-          child: Text(
-            useVideo ? '${pool!.size}' : '0',
-            key: const Key('active-controllers'),
-            style: const TextStyle(fontSize: 10),
-          ),
-        ),
-      ],
+    final adapter = VideoScope.of(context);
+    return adapter.build(
+      url: url,
+      autoplay: autoplay,
+      muted: muted,
+      fit: fit,
+      onReady: onReady,
     );
   }
 }

--- a/lib/ui/widgets/app_icon.dart
+++ b/lib/ui/widgets/app_icon.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+/// Simple wrapper to map string-based asset names to [IconData].
+class AppIcon extends StatelessWidget {
+  final String name;
+  const AppIcon(this.name, {super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    IconData icon;
+    switch (name) {
+      case 'bell_24':
+        icon = Icons.notifications;
+        break;
+      default:
+        icon = Icons.circle;
+    }
+    return Icon(icon);
+  }
+}

--- a/scripts/dev/find_placeholders.sh
+++ b/scripts/dev/find_placeholders.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+if grep -R "Placeholder(" lib >/dev/null 2>&1; then
+  echo "Error: Found Placeholder() in lib/. Remove debug placeholders before commit."
+  exit 1
+fi
+echo "OK: no Placeholder widgets found."


### PR DESCRIPTION
## Summary
- replace debug placeholder with real `HomePage` mounting overlay-first UI
- add simple `VideoPlayerView` using `VideoScope` adapter and demo video
- guard against placeholder regressions via CI script

## Testing
- `bash scripts/dev/find_placeholders.sh`
- `flutter clean && flutter pub get` *(fails: command not found)*
- `flutter run -d chrome --web-renderer html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a01cccc2f8833198ef7653df39bcef