### PR TITLE
Add FeedController and HUD bindings with gestures and shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,19 @@ If the page is still blank, open DevTools → Console and copy the first error. 
 We use a single `OverlayEntry` controlled by `HudState` (ValueNotifiers). Toggling visibility or
 muting updates only the overlay subtree; the `PageView` feed is never rebuilt.
 
+### Controller
+`FeedController` owns the current index and muted state. HUD buttons and keyboard shortcuts drive
+the controller; `FeedPager` listens and rebuilds only the visible page when mute changes.
+Double-tap on a video likes the current item (demo increments count).
+
 Commands
-- flutter clean && flutter pub get
+- flutter clean
+- flutter pub get
 - flutter run -d chrome
 - flutter test
 
 Acceptance
-- Long-press hides/shows overlays smoothly.
-- Scrolling feed remains uninterrupted; PageView stays mounted.
-- No rebuilds of the feed when toggling HUD (tests pass).
+- Clicking “Unmute/Mute” actually toggles the playing video’s audio.
+- Double-tap anywhere on the video increments the like count shown in the HUD.
+- Keyboard: ↑/↓ scrolls feed; M toggles mute; L likes.
+- PageView remains mounted when toggling HUD or mute (previous tests still pass).

--- a/lib/feed/demo_feed.dart
+++ b/lib/feed/demo_feed.dart
@@ -1,12 +1,12 @@
 class FeedItem {
   final String url;
   final String caption;
-  final String likeCount;
-  final String commentCount;
-  final String repostCount;
-  final String shareCount;
-  final String zapCount;
-  const FeedItem({
+  String likeCount;
+  String commentCount;
+  String repostCount;
+  String shareCount;
+  String zapCount;
+  FeedItem({
     required this.url,
     required this.caption,
     this.likeCount = '0',
@@ -17,7 +17,7 @@ class FeedItem {
   });
 }
 
-const demoFeed = <FeedItem>[
+final demoFeed = <FeedItem>[
   FeedItem(
     url: 'https://flutter.github.io/assets-for-api-docs/assets/videos/bee.mp4',
     caption: 'Enjoying a sunny day #nature #sydney #nostr',

--- a/lib/ui/home/feed_controller.dart
+++ b/lib/ui/home/feed_controller.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class FeedController extends ChangeNotifier {
+  final ValueNotifier<int> index = ValueNotifier<int>(0);
+  final ValueNotifier<bool> muted = ValueNotifier<bool>(true);
+
+  PageController? _pager;
+
+  void attach(PageController pager) => _pager = pager;
+
+  void next() => _pager?.nextPage(duration: const Duration(milliseconds: 250), curve: Curves.easeOut);
+  void prev() => _pager?.previousPage(duration: const Duration(milliseconds: 250), curve: Curves.easeOut);
+
+  void toggleMute() => muted.value = !muted.value;
+
+  @override
+  void dispose() {
+    index.dispose();
+    muted.dispose();
+    super.dispose();
+  }
+}

--- a/lib/ui/home/widgets/feed_pager.dart
+++ b/lib/ui/home/widgets/feed_pager.dart
@@ -110,6 +110,7 @@ class _FeedPageState extends State<_FeedPage>
         autoplay: widget.autoplay,
         muted: widget.muted,
         fit: BoxFit.cover,
+        onReady: () {},
       ),
     );
   }

--- a/lib/ui/home/widgets/feed_pager.dart
+++ b/lib/ui/home/widgets/feed_pager.dart
@@ -26,6 +26,7 @@ class FeedPager extends StatefulWidget {
 class _FeedPagerState extends State<FeedPager> {
   late final PageController _controller = PageController();
   int _index = 0;
+  bool _didWarmUp = false;
 
   @override
   void initState() {
@@ -37,7 +38,15 @@ class _FeedPagerState extends State<FeedPager> {
     widget.controller.muted.addListener(() {
       setState(() {});
     });
-    _warmUp(_index);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    if (!_didWarmUp) {
+      _didWarmUp = true;
+      _warmUp(_index);
+    }
   }
 
   void _warmUp(int i) {

--- a/lib/ui/home/widgets/feed_pager.dart
+++ b/lib/ui/home/widgets/feed_pager.dart
@@ -99,7 +99,11 @@ class _FeedPage extends StatefulWidget {
   final FeedItem item;
   final bool autoplay;
   final bool muted;
-  const _FeedPage({super.key, required this.item, required this.autoplay, required this.muted});
+  const _FeedPage(
+      {super.key,
+      required this.item,
+      required this.autoplay,
+      required this.muted});
 
   @override
   State<_FeedPage> createState() => _FeedPageState();
@@ -113,7 +117,7 @@ class _FeedPageState extends State<_FeedPage>
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    return Positioned.fill(
+    return SizedBox.expand(
       child: VideoPlayerView(
         url: widget.item.url,
         autoplay: widget.autoplay,
@@ -124,4 +128,3 @@ class _FeedPageState extends State<_FeedPage>
     );
   }
 }
-

--- a/lib/ui/home/widgets/feed_pager.dart
+++ b/lib/ui/home/widgets/feed_pager.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../../video/video_adapter.dart';
 import '../../../feed/demo_feed.dart';
+import '../feed_controller.dart';
 import 'video_player_view.dart';
 
 typedef OnIndexChanged = void Function(int index);
@@ -8,12 +9,14 @@ typedef OnIndexChanged = void Function(int index);
 class FeedPager extends StatefulWidget {
   final List<FeedItem> items;
   final OnIndexChanged onIndexChanged;
-  final bool muted;
+  final FeedController controller;
+  final void Function(int index)? onDoubleTapLike;
   const FeedPager({
     super.key,
     required this.items,
     required this.onIndexChanged,
-    required this.muted,
+    required this.controller,
+    this.onDoubleTapLike,
   });
 
   @override
@@ -23,7 +26,19 @@ class FeedPager extends StatefulWidget {
 class _FeedPagerState extends State<FeedPager> {
   late final PageController _controller = PageController();
   int _index = 0;
-  bool _didInitialWarmUp = false;
+
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.attach(_controller);
+    widget.controller.index.addListener(() {
+      // external programmatic moves (not used yet)
+    });
+    widget.controller.muted.addListener(() {
+      setState(() {});
+    });
+    _warmUp(_index);
+  }
 
   void _warmUp(int i) {
     final adapter = VideoScope.of(context);
@@ -31,15 +46,6 @@ class _FeedPagerState extends State<FeedPager> {
     if (i + 1 < widget.items.length) urls.add(widget.items[i + 1].url);
     if (i - 1 >= 0) urls.add(widget.items[i - 1].url);
     adapter.warmUp(urls);
-  }
-
-  @override
-  void didChangeDependencies() {
-    super.didChangeDependencies();
-    if (!_didInitialWarmUp) {
-      _didInitialWarmUp = true;
-      _warmUp(_index);
-    }
   }
 
   @override
@@ -56,6 +62,7 @@ class _FeedPagerState extends State<FeedPager> {
       scrollDirection: Axis.vertical,
       onPageChanged: (i) {
         setState(() => _index = i);
+        widget.controller.index.value = i;
         widget.onIndexChanged(i);
         _warmUp(i);
       },
@@ -63,11 +70,16 @@ class _FeedPagerState extends State<FeedPager> {
       itemBuilder: (context, i) {
         final item = widget.items[i];
         final isCurrent = i == _index;
-        return _FeedPage(
-          key: ValueKey('feed_$i'),
-          item: item,
-          autoplay: isCurrent,
-          muted: widget.muted,
+        return GestureDetector(
+          onDoubleTap: isCurrent && widget.onDoubleTapLike != null
+              ? () => widget.onDoubleTapLike!.call(i)
+              : null,
+          child: _FeedPage(
+            key: ValueKey('feed_$i'),
+            item: item,
+            autoplay: isCurrent,
+            muted: widget.controller.muted.value,
+          ),
         );
       },
     );
@@ -78,12 +90,7 @@ class _FeedPage extends StatefulWidget {
   final FeedItem item;
   final bool autoplay;
   final bool muted;
-  const _FeedPage({
-    super.key,
-    required this.item,
-    required this.autoplay,
-    required this.muted,
-  });
+  const _FeedPage({super.key, required this.item, required this.autoplay, required this.muted});
 
   @override
   State<_FeedPage> createState() => _FeedPageState();
@@ -97,13 +104,12 @@ class _FeedPageState extends State<_FeedPage>
   @override
   Widget build(BuildContext context) {
     super.build(context);
-    return SizedBox.expand(
+    return Positioned.fill(
       child: VideoPlayerView(
         url: widget.item.url,
         autoplay: widget.autoplay,
         muted: widget.muted,
         fit: BoxFit.cover,
-        onReady: () {},
       ),
     );
   }

--- a/lib/ui/overlay/hud_overlay.dart
+++ b/lib/ui/overlay/hud_overlay.dart
@@ -1,149 +1,145 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import '../design/tokens.dart';
 import '../widgets/app_icon.dart';
 import '../home/widgets/overlay_cluster.dart';
 import 'hud_model.dart';
+import '../home/feed_controller.dart';
 
 class HudOverlay extends StatelessWidget {
   final HudState state;
-  final VoidCallback onLike;
-  final VoidCallback onComment;
-  final VoidCallback onRepost;
-  final VoidCallback onShare;
-  final VoidCallback onSave;
-  final VoidCallback onZap;
+  final FeedController controller;
+  final VoidCallback onLikeLogical;
 
   const HudOverlay({
     super.key,
     required this.state,
-    required this.onLike,
-    required this.onComment,
-    required this.onRepost,
-    required this.onShare,
-    required this.onSave,
-    required this.onZap,
+    required this.controller,
+    required this.onLikeLogical,
   });
 
   @override
   Widget build(BuildContext context) {
-    return ValueListenableBuilder<bool>(
-      valueListenable: state.visible,
-      builder: (_, visible, __) {
-        final overlay = Material(
-          type: MaterialType.transparency,
-          child: IgnorePointer(
-            ignoring: !visible,
-            child: SafeArea(
-              child: Stack(
-              children: [
-                // Bell
-                Positioned(
-                  right: T.s24,
-                  top: T.s24,
-                  child: const SizedBox(
-                    width: 48,
-                    height: 48,
-                    child: Center(child: AppIcon('bell_24')),
-                  ),
-                ),
-                // Right action stack
-                Positioned(
-                  right: 20,
-                  bottom: MediaQuery.of(context).size.height * 0.16,
-                  child: ValueListenableBuilder<HudModel>(
-                    valueListenable: state.model,
-                    builder: (_, m, __) => OverlayCluster(
-                      onLike: onLike,
-                      onComment: onComment,
-                      onRepost: onRepost,
-                      onShare: onShare,
-                      onCopyLink: onSave,
-                      onZap: onZap,
-                      likeCount: m.likeCount,
-                      commentCount: m.commentCount,
-                      repostCount: m.repostCount,
-                      shareCount: m.shareCount,
-                      zapCount: m.zapCount,
-                    ),
-                  ),
-                ),
-                // Caption
-                Positioned(
-                  left: T.s24,
-                  right: T.s24,
-                  bottom: MediaQuery.of(context).size.height * 0.22,
-                  child: ValueListenableBuilder<HudModel>(
-                    valueListenable: state.model,
-                    builder: (_, m, __) => Container(
-                      padding: const EdgeInsets.all(12),
-                      decoration: BoxDecoration(
-                        color: Colors.white.withValues(alpha: 0.10),
-                        borderRadius: BorderRadius.circular(T.r16),
-                      ),
-                      child: Text(
-                        m.caption,
-                        style: Theme.of(context).textTheme.bodyMedium,
+    return CallbackShortcuts(
+      bindings: <ShortcutActivator, VoidCallback>{
+        const SingleActivator(LogicalKeyboardKey.arrowDown): controller.next,
+        const SingleActivator(LogicalKeyboardKey.arrowUp): controller.prev,
+        const SingleActivator(LogicalKeyboardKey.keyM): controller.toggleMute,
+        const SingleActivator(LogicalKeyboardKey.keyL): onLikeLogical,
+      },
+      child: Focus(
+        autofocus: true,
+        child: ValueListenableBuilder<bool>(
+          valueListenable: state.visible,
+          builder: (_, visible, __) {
+            final overlay = IgnorePointer(
+              ignoring: !visible,
+              child: SafeArea(
+                child: Stack(
+                  children: [
+                    Positioned(
+                      right: T.s24,
+                      top: T.s24,
+                      child: const SizedBox(
+                        width: 48,
+                        height: 48,
+                        child: Center(child: AppIcon('bell_24')),
                       ),
                     ),
-                  ),
-                ),
-                // Web-only mute
-                if (kIsWeb)
-                  Positioned(
-                    left: T.s24,
-                    bottom: MediaQuery.of(context).size.height * 0.28,
-                    child: ValueListenableBuilder<bool>(
-                      valueListenable: state.muted,
-                      builder: (_, muted, __) => ElevatedButton(
-                        onPressed: () => state.muted.value = !muted,
-                        child: Text(muted ? 'Unmute' : 'Mute'),
+                    Positioned(
+                      right: 20,
+                      bottom: MediaQuery.of(context).size.height * 0.16,
+                      child: ValueListenableBuilder<HudModel>(
+                        valueListenable: state.model,
+                        builder: (_, m, __) => OverlayCluster(
+                          onLike: onLikeLogical,
+                          onComment: () {},
+                          onRepost: () {},
+                          onShare: () {},
+                          onCopyLink: () {},
+                          onZap: () {},
+                          likeCount: m.likeCount,
+                          commentCount: m.commentCount,
+                          repostCount: m.repostCount,
+                          shareCount: m.shareCount,
+                          zapCount: m.zapCount,
+                        ),
                       ),
                     ),
-                  ),
-                // Bottom centre Create
-                Positioned(
-                  left: 0,
-                  right: 0,
-                  bottom: T.s24,
-                  child: Column(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Container(
-                        width: 56,
-                        height: 56,
-                        decoration: BoxDecoration(
-                          borderRadius: BorderRadius.circular(28),
-                          border: Border.all(
-                            color: Colors.white.withValues(alpha: 0.85),
-                            width: 2,
+                    Positioned(
+                      left: T.s24,
+                      right: T.s24,
+                      bottom: MediaQuery.of(context).size.height * 0.22,
+                      child: ValueListenableBuilder<HudModel>(
+                        valueListenable: state.model,
+                        builder: (_, m, __) => Container(
+                          padding: const EdgeInsets.all(12),
+                          decoration: BoxDecoration(
+                            color: Colors.white.withOpacity(0.10),
+                            borderRadius: BorderRadius.circular(T.r16),
+                          ),
+                          child: Text(
+                            m.caption,
+                            style: Theme.of(context).textTheme.bodyMedium,
                           ),
                         ),
                       ),
-                      const SizedBox(height: 8),
-                      const Text('Create', style: TextStyle(color: Colors.white)),
-                    ],
-                  ),
+                    ),
+                    if (kIsWeb)
+                      Positioned(
+                        left: T.s24,
+                        bottom: MediaQuery.of(context).size.height * 0.28,
+                        child: ValueListenableBuilder<bool>(
+                          valueListenable: controller.muted,
+                          builder: (_, muted, __) => ElevatedButton(
+                            onPressed: controller.toggleMute,
+                            child: Text(muted ? 'Unmute' : 'Mute'),
+                          ),
+                        ),
+                      ),
+                    Positioned(
+                      left: 0,
+                      right: 0,
+                      bottom: T.s24,
+                      child: Column(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          Container(
+                            width: 56,
+                            height: 56,
+                            decoration: BoxDecoration(
+                              borderRadius: BorderRadius.circular(28),
+                              border: Border.all(
+                                color: Colors.white.withOpacity(0.85),
+                                width: 2,
+                              ),
+                            ),
+                          ),
+                          const SizedBox(height: 8),
+                          const Text('Create', style: TextStyle(color: Colors.white)),
+                        ],
+                      ),
+                    ),
+                    Positioned.fill(
+                      child: GestureDetector(
+                        onLongPress: () => state.visible.value = !state.visible.value,
+                        behavior: HitTestBehavior.translucent,
+                      ),
+                    ),
+                  ],
                 ),
-                // Top-most gesture layer to toggle without setState on HomePage
-                Positioned.fill(
-                  child: GestureDetector(
-                    onLongPress: () => state.visible.value = !state.visible.value,
-                    behavior: HitTestBehavior.translucent,
-                  ),
-                ),
-              ],
               ),
-            ),
-          ),
-        );
+            );
 
-        return AnimatedOpacity(
-          duration: const Duration(milliseconds: 150),
-          opacity: visible ? 1 : 0,
-          child: overlay,
-        );
-      },
+            return AnimatedOpacity(
+              duration: const Duration(milliseconds: 150),
+              opacity: visible ? 1 : 0,
+              child: overlay,
+            );
+          },
+        ),
+      ),
     );
   }
 }

--- a/lib/ui/overlay/hud_overlay.dart
+++ b/lib/ui/overlay/hud_overlay.dart
@@ -35,9 +35,11 @@ class HudOverlay extends StatelessWidget {
           builder: (_, visible, __) {
             final overlay = IgnorePointer(
               ignoring: !visible,
-              child: SafeArea(
-                child: Stack(
-                  children: [
+              child: Material(
+                type: MaterialType.transparency,
+                child: SafeArea(
+                  child: Stack(
+                    children: [
                     Positioned(
                       right: T.s24,
                       top: T.s24,
@@ -130,7 +132,8 @@ class HudOverlay extends StatelessWidget {
                   ],
                 ),
               ),
-            );
+            ),
+          );
 
             return AnimatedOpacity(
               duration: const Duration(milliseconds: 150),

--- a/lib/ui/overlay/hud_overlay.dart
+++ b/lib/ui/overlay/hud_overlay.dart
@@ -76,7 +76,7 @@ class HudOverlay extends StatelessWidget {
                         builder: (_, m, __) => Container(
                           padding: const EdgeInsets.all(12),
                           decoration: BoxDecoration(
-                            color: Colors.white.withOpacity(0.10),
+                            color: Colors.white.withValues(alpha: 0.10),
                             borderRadius: BorderRadius.circular(T.r16),
                           ),
                           child: Text(
@@ -111,7 +111,7 @@ class HudOverlay extends StatelessWidget {
                             decoration: BoxDecoration(
                               borderRadius: BorderRadius.circular(28),
                               border: Border.all(
-                                color: Colors.white.withOpacity(0.85),
+                                color: Colors.white.withValues(alpha: 0.85),
                                 width: 2,
                               ),
                             ),

--- a/test/ui/mute_toggle_updates_current_page_test.dart
+++ b/test/ui/mute_toggle_updates_current_page_test.dart
@@ -1,10 +1,11 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:nostr_video/ui/home/home_page.dart';
+import '../test_helpers/test_video_scope.dart';
 
 void main() {
   testWidgets('Mute toggle updates current page without removing PageView', (t) async {
-    await t.pumpWidget(const MaterialApp(home: HomePage()));
+    await t.pumpWidget(const TestVideoApp(child: MaterialApp(home: HomePage())));
     await t.pumpAndSettle();
 
     expect(find.byType(PageView), findsOneWidget);

--- a/test/ui/mute_toggle_updates_current_page_test.dart
+++ b/test/ui/mute_toggle_updates_current_page_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:nostr_video/ui/home/home_page.dart';
+
+void main() {
+  testWidgets('Mute toggle updates current page without removing PageView', (t) async {
+    await t.pumpWidget(const MaterialApp(home: HomePage()));
+    await t.pumpAndSettle();
+
+    expect(find.byType(PageView), findsOneWidget);
+
+    final unmute = find.textContaining('Mute', findRichText: true);
+    expect(unmute, findsOneWidget);
+
+    await t.tap(unmute);
+    await t.pump(const Duration(milliseconds: 50));
+
+    expect(find.byType(PageView), findsOneWidget);
+  });
+}

--- a/test/ui/mute_toggle_updates_current_page_test.dart
+++ b/test/ui/mute_toggle_updates_current_page_test.dart
@@ -1,21 +1,24 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_video/ui/home/home_page.dart';
 import '../test_helpers/test_video_scope.dart';
 
 void main() {
-  testWidgets('Mute toggle updates current page without removing PageView', (t) async {
-    await t.pumpWidget(const TestVideoApp(child: MaterialApp(home: HomePage())));
+  testWidgets('Mute toggle updates current page without removing PageView',
+      (t) async {
+    await t.pumpWidget(
+      const TestVideoApp(child: MaterialApp(home: HomePage())),
+    );
     await t.pumpAndSettle();
 
     expect(find.byType(PageView), findsOneWidget);
 
-    final unmute = find.textContaining('Mute', findRichText: true);
-    expect(unmute, findsOneWidget);
+    // Keyboard shortcut `M` toggles mute via the controller.
+    await t.sendKeyDownEvent(LogicalKeyboardKey.keyM);
+    await t.pump();
 
-    await t.tap(unmute);
-    await t.pump(const Duration(milliseconds: 50));
-
+    // PageView must still be mounted after mute toggle.
     expect(find.byType(PageView), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add FeedController for index/mute state and navigation helpers
- wire FeedPager and HudOverlay to controller with double-tap like and shortcuts
- document controller usage and test mute toggle rebuild

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0625e3a608331a5d95875debe0395