### PR TITLE
Respect NOSTR_ENABLED flag and improve Nostr mapping

### DIFF
--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -1,11 +1,22 @@
-/// Build flag: flutter run -d chrome --dart-define=NOSTR_ENABLED=true
-const bool kNostrEnabled = bool.fromEnvironment('NOSTR_ENABLED', defaultValue: false);
+import 'package:flutter/foundation.dart'; // ignore: unused_import
 
-/// Default relays (edit to taste, or load from settings later).
+/// Build flag: flutter run -d chrome --dart-define=NOSTR_ENABLED=true
+const bool kNostrEnabled = bool.fromEnvironment(
+  'NOSTR_ENABLED',
+  defaultValue: false,
+);
+
+// Add more relays (websocket friendly)
 const List<String> kDefaultRelays = <String>[
   'wss://relay.damus.io',
   'wss://nos.lol',
+  'wss://relay.snort.social',
+  'wss://eden.nostr.land',
+  'wss://nostr.fmt.wiz.biz',
 ];
 
 /// How many items to request initially.
-const int kNostrInitialLimit = 50;
+const int kNostrInitialLimit = 80;
+
+/// Timeout for initial load before showing empty state.
+const Duration kNostrLoadTimeout = Duration(seconds: 6);


### PR DESCRIPTION
## Summary
- Load relays only when `NOSTR_ENABLED` is set and expose additional relay defaults and timeout
- Broaden video URL extraction to cover more Nostr tag patterns
- Start with empty feed when Nostr enabled and show loading/empty states with debug logs

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68a1083eb39483319b406284c2469279