### PR TITLE
Clamp caption and show full text on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ Vector icons are loaded from `assets/icons/*.svg.vec`. In dev, if the `.vec` isn
 present yet, `AppIcon` falls back to a Material icon so the UI never shows
 empty slots.
 
+### Caption behaviour
+- Overlay caption is clamped to 3 lines with a subtle backdrop and max width (≤ 78% of viewport, capped at 520 px).
+- Very long tokens and bech32 refs are wrapped/trimmed for readability.
+- Tap **More** to read the full caption in a bottom sheet.
+
 ### Sharing
 - Share button uses the Web Share API when available; otherwise it copies a deep link to the clipboard.
 - Counts are formatted consistently via `utils/count_format.dart`.

--- a/lib/ui/home/home_page.dart
+++ b/lib/ui/home/home_page.dart
@@ -12,6 +12,7 @@ import '../../config/app_config.dart';
 import '../../web/url_shim.dart'
     if (dart.library.html) '../../web/url_shim_web.dart';
 import '../../utils/count_format.dart';
+import '../../utils/caption_format.dart';
 import '../../platform/share_shim.dart'
     if (dart.library.html) '../../platform/share_shim_web.dart';
 
@@ -39,13 +40,14 @@ class _HomePageState extends State<HomePage> {
     muted: _controller.muted,
     model: ValueNotifier<HudModel>(
       kNostrEnabled
-          ? const HudModel(caption: 'Loading Nostr…')
+          ? const HudModel(caption: 'Loading Nostr…', fullCaption: 'Loading Nostr…')
           : _modelFromItem(_items[0]),
     ),
   );
 
   HudModel _modelFromItem(FeedItem f) => HudModel(
-        caption: f.caption,
+        caption: CaptionFormat.display(f.caption),
+        fullCaption: f.caption,
         likeCount: f.likeCount,
         commentCount: f.commentCount,
         repostCount: f.repostCount,
@@ -102,6 +104,8 @@ class _HomePageState extends State<HomePage> {
           // keep HUD model text but do not flip back to demo
           _hud.model.value = _hud.model.value.copyWith(
             caption:
+                'No Nostr videos found yet. Pull to refresh or try another relay.',
+            fullCaption:
                 'No Nostr videos found yet. Pull to refresh or try another relay.',
           );
           _initialIndex = 0;

--- a/lib/ui/overlay/hud_model.dart
+++ b/lib/ui/overlay/hud_model.dart
@@ -2,6 +2,7 @@ import 'package:flutter/foundation.dart';
 
 class HudModel {
   final String caption;
+  final String fullCaption;
   final String likeCount;
   final String commentCount;
   final String repostCount;
@@ -11,6 +12,7 @@ class HudModel {
   final String authorNpub;
   const HudModel({
     required this.caption,
+    required this.fullCaption,
     this.likeCount = '0',
     this.commentCount = '0',
     this.repostCount = '0',
@@ -22,6 +24,7 @@ class HudModel {
 
   HudModel copyWith({
     String? caption,
+    String? fullCaption,
     String? likeCount,
     String? commentCount,
     String? repostCount,
@@ -31,6 +34,7 @@ class HudModel {
     String? authorNpub,
   }) => HudModel(
     caption: caption ?? this.caption,
+    fullCaption: fullCaption ?? this.fullCaption,
     likeCount: likeCount ?? this.likeCount,
     commentCount: commentCount ?? this.commentCount,
     repostCount: repostCount ?? this.repostCount,

--- a/lib/ui/overlay/widgets/bottom_info_bar.dart
+++ b/lib/ui/overlay/widgets/bottom_info_bar.dart
@@ -16,6 +16,7 @@ class BottomInfoBar extends StatelessWidget {
   Widget build(BuildContext context) {
     final size = MediaQuery.of(context).size;
     final maxW = min(size.width * 0.78, 520.0);
+    final showMore = model.fullCaption.trim() != model.caption.trim();
 
     return ConstrainedBox(
       constraints: BoxConstraints(maxWidth: maxW),
@@ -31,7 +32,7 @@ class BottomInfoBar extends StatelessWidget {
                 height: 32,
                 decoration: BoxDecoration(
                   shape: BoxShape.circle,
-                  color: Colors.white.withValues(alpha: 0.15),
+                  color: Colors.white.withOpacity(0.15),
                 ),
                 child: const Icon(Icons.person, size: 18, color: Colors.white),
               ),
@@ -56,22 +57,85 @@ class BottomInfoBar extends StatelessWidget {
             ],
           ),
           const SizedBox(height: 10),
-          // Caption with translucent backdrop
-          Container(
-            padding: const EdgeInsets.all(12),
-            decoration: BoxDecoration(
-              color: Colors.black.withValues(alpha: 0.30),
-              borderRadius: BorderRadius.circular(T.r16),
-            ),
-            child: Text(
-              model.caption,
-              style: Theme.of(context)
-                  .textTheme
-                  .bodyMedium
-                  ?.copyWith(color: Colors.white),
-            ),
+          // Caption (clamped to 3 lines with fade)
+          Stack(
+            children: [
+              ClipRect(
+                child: Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: Colors.black.withOpacity(0.30),
+                    borderRadius: BorderRadius.circular(T.r16),
+                  ),
+                  child: Text(
+                    model.caption,
+                    maxLines: 3,
+                    overflow: TextOverflow.fade,
+                    softWrap: true,
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodyMedium
+                        ?.copyWith(color: Colors.white, height: 1.25),
+                  ),
+                ),
+              ),
+              if (showMore)
+                Positioned(
+                  right: 8,
+                  bottom: 8,
+                  child: TextButton(
+                    style: TextButton.styleFrom(
+                      foregroundColor: Colors.white,
+                      backgroundColor: Colors.black.withOpacity(0.35),
+                      padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
+                      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                    ),
+                    onPressed: () => _openFullCaption(context, model),
+                    child: const Text('More'),
+                  ),
+                ),
+            ],
           ),
         ],
+      ),
+    );
+  }
+
+  void _openFullCaption(BuildContext context, HudModel m) {
+    showModalBottomSheet(
+      context: context,
+      useRootNavigator: true,
+      isScrollControlled: true,
+      backgroundColor: const Color(0xFF0E0E11),
+      shape: const RoundedRectangleBorder(
+        borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+      ),
+      builder: (ctx) => DraggableScrollableSheet(
+        expand: false,
+        initialChildSize: 0.6,
+        maxChildSize: 0.9,
+        builder: (_, controller) => Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 16),
+          child: ListView(
+            controller: controller,
+            children: [
+              Row(
+                children: [
+                  const Icon(Icons.person, color: Colors.white70, size: 18),
+                  const SizedBox(width: 8),
+                  Text(m.authorDisplay, style: const TextStyle(color: Colors.white, fontWeight: FontWeight.w600)),
+                  const SizedBox(width: 8),
+                  Text(_short(m.authorNpub), style: const TextStyle(color: Colors.white54, fontSize: 12)),
+                ],
+              ),
+              const SizedBox(height: 12),
+              SelectableText(
+                m.fullCaption,
+                style: const TextStyle(color: Colors.white, height: 1.35),
+              ),
+            ],
+          ),
+        ),
       ),
     );
   }

--- a/lib/ui/overlay/widgets/bottom_info_bar.dart
+++ b/lib/ui/overlay/widgets/bottom_info_bar.dart
@@ -32,7 +32,7 @@ class BottomInfoBar extends StatelessWidget {
                 height: 32,
                 decoration: BoxDecoration(
                   shape: BoxShape.circle,
-                  color: Colors.white.withOpacity(0.15),
+                  color: Colors.white.withValues(alpha: 0.15),
                 ),
                 child: const Icon(Icons.person, size: 18, color: Colors.white),
               ),
@@ -64,7 +64,7 @@ class BottomInfoBar extends StatelessWidget {
                 child: Container(
                   padding: const EdgeInsets.all(12),
                   decoration: BoxDecoration(
-                    color: Colors.black.withOpacity(0.30),
+                    color: Colors.black.withValues(alpha: 0.30),
                     borderRadius: BorderRadius.circular(T.r16),
                   ),
                   child: Text(
@@ -86,7 +86,7 @@ class BottomInfoBar extends StatelessWidget {
                   child: TextButton(
                     style: TextButton.styleFrom(
                       foregroundColor: Colors.white,
-                      backgroundColor: Colors.black.withOpacity(0.35),
+                      backgroundColor: Colors.black.withValues(alpha: 0.35),
                       padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 6),
                       shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
                     ),

--- a/lib/utils/caption_format.dart
+++ b/lib/utils/caption_format.dart
@@ -1,0 +1,34 @@
+/// Basic helpers to make Nostr captions readable on overlay.
+class CaptionFormat {
+  // Matches nostr:npub1..., nostr:nprofile1..., nostr:note1..., nostr:nevent1...
+  static final _nostrRef = RegExp(r'nostr:(?:npub1|nprofile1|note1|nevent1)[a-z0-9]+', caseSensitive: false);
+  // Strip direct video links; they’re already used by the player.
+  static final _videoUrl = RegExp(r'https?:\/\/\S+\.(?:mp4|webm|m3u8)\b', caseSensitive: false);
+  // Condense whitespace
+  static final _ws = RegExp(r'\s+');
+
+  /// Insert zero-width space every [chunk] chars for long unbroken tokens,
+  /// so Flutter Web can wrap them.
+  static String wrapLongTokens(String s, {int chunk = 18}) {
+    return s.splitMapJoin(
+      RegExp(r'[^\s]{40,}'),
+      onMatch: (m) {
+        final t = m[0]!;
+        final b = StringBuffer();
+        for (var i = 0; i < t.length; i += chunk) {
+          b.write(t.substring(i, i + chunk > t.length ? t.length : i + chunk));
+          if (i + chunk < t.length) b.write('\u200B'); // zero-width space
+        }
+        return b.toString();
+      },
+      onNonMatch: (n) => n,
+    );
+  }
+
+  /// Display text for overlay: remove bech32 refs and video URLs, condense whitespace.
+  static String display(String raw) {
+    var s = raw.replaceAll(_nostrRef, '').replaceAll(_videoUrl, '');
+    s = s.replaceAll(_ws, ' ').trim();
+    return wrapLongTokens(s);
+  }
+}

--- a/test/ui/caption_display_test.dart
+++ b/test/ui/caption_display_test.dart
@@ -5,7 +5,7 @@ import 'package:flutter/material.dart';
 
 void main() {
   testWidgets('caption clamps to 3 lines and shows More when cleaned differs', (t) async {
-    final long = 'nostr:npub1'.padRight(200, 'x') + ' https://a.dev/v.mp4 ' + List.filled(50, 'word').join(' ');
+    final long = '${'nostr:npub1'.padRight(200, 'x')} https://a.dev/v.mp4 ${List.filled(50, 'word').join(' ')}';
     final m = HudModel(
       caption: 'short',
       fullCaption: long,

--- a/test/ui/caption_display_test.dart
+++ b/test/ui/caption_display_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_video/ui/overlay/widgets/bottom_info_bar.dart';
+import 'package:nostr_video/ui/overlay/hud_model.dart';
+import 'package:flutter/material.dart';
+
+void main() {
+  testWidgets('caption clamps to 3 lines and shows More when cleaned differs', (t) async {
+    final long = 'nostr:npub1'.padRight(200, 'x') + ' https://a.dev/v.mp4 ' + List.filled(50, 'word').join(' ');
+    final m = HudModel(
+      caption: 'short',
+      fullCaption: long,
+      likeCount: '0',
+      commentCount: '0',
+      repostCount: '0',
+      shareCount: '0',
+      zapCount: '0',
+      authorDisplay: 'Tester',
+      authorNpub: 'npub1abcd…wxyz',
+    );
+    await t.pumpWidget(MaterialApp(home: Scaffold(body: BottomInfoBar(model: m))));
+    expect(find.text('More'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- strip Nostr IDs and video URLs from overlay captions and wrap long tokens
- add `fullCaption` to HUD model and clamp overlay caption to three lines with a More sheet
- document and test new caption behaviour

## Testing
- `flutter test test/ui/caption_display_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a11078a0dc8331850dd392803b7d9e