### PR TITLE
Viewer avatar bubble with account menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ A privacy-first short-video client:
 - NIP-96 upload → NIP-94 tags on posts
 - Likes (kind 7), comments (kind 1 replies), zaps (9734/9735)
 - Offline queue + relay backoff
+- **Viewer avatar:** bottom-right, always shown when HUD is visible. Tap to open the account menu. Falls back to coloured initials if there’s no picture.
+- Hides when HUD is hidden (long-press anywhere to toggle).
 
 ## Quickstart
 ```bash

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'app.dart';
 import 'video/video_adapter.dart';
 import 'video/video_adapter_real.dart';
+import 'session/user_session.dart';
 
 // Conditional import: on web use the real implementation, elsewhere the stub.
 import 'util/sw_debug_stub.dart'
@@ -25,6 +26,13 @@ Future<void> main() async {
       }
       return true;
     }());
+
+    // Set a placeholder viewer profile until auth is wired.
+    userSession.current.value = const UserProfile(
+      npub: 'npub1guest',
+      displayName: 'You',
+      pictureUrl: null,
+    );
 
     runApp(VideoScope(adapter: RealVideoAdapter(), child: const App()));
   }, (Object error, StackTrace stack) {

--- a/lib/session/user_session.dart
+++ b/lib/session/user_session.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/foundation.dart';
+
+class UserProfile {
+  final String npub;
+  final String? displayName;
+  final String? pictureUrl;
+  const UserProfile({required this.npub, this.displayName, this.pictureUrl});
+}
+
+/// Very simple global until auth is wired.
+class UserSession {
+  final current = ValueNotifier<UserProfile?>(null);
+}
+
+final userSession = UserSession();

--- a/lib/ui/overlay/hud_overlay.dart
+++ b/lib/ui/overlay/hud_overlay.dart
@@ -8,6 +8,8 @@ import 'hud_model.dart';
 import '../home/feed_controller.dart';
 import 'widgets/search_pill.dart';
 import 'widgets/bottom_info_bar.dart';
+import 'widgets/viewer_avatar.dart';
+import 'widgets/account_menu.dart';
 
 class HudOverlay extends StatelessWidget {
   final HudState state;
@@ -185,6 +187,13 @@ class HudOverlay extends StatelessWidget {
                               child: ValueListenableBuilder<HudModel>(
                                 valueListenable: state.model,
                                 builder: (_, m, __) => BottomInfoBar(model: m),
+                              ),
+                            ),
+                            Positioned(
+                              right: 16,
+                              bottom: 16 + MediaQuery.of(context).padding.bottom,
+                              child: ViewerAvatar(
+                                onTap: () => showAccountMenu(context),
                               ),
                             ),
                             Positioned(

--- a/lib/ui/overlay/widgets/account_menu.dart
+++ b/lib/ui/overlay/widgets/account_menu.dart
@@ -1,0 +1,62 @@
+import 'package:flutter/material.dart';
+import '../../../session/user_session.dart';
+
+Future<void> showAccountMenu(BuildContext context) async {
+  final p = userSession.current.value;
+  await showModalBottomSheet(
+    context: context,
+    backgroundColor: const Color(0xFF0E0E11),
+    shape: const RoundedRectangleBorder(
+      borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+    ),
+    builder: (_) => SafeArea(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                CircleAvatar(
+                  radius: 18,
+                  backgroundColor: Colors.white24,
+                  child: const Icon(Icons.person, color: Colors.white),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Text(
+                    p?.displayName ?? 'Guest',
+                    style: const TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.w600,
+                    ),
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            ListTile(
+              leading: const Icon(Icons.notifications, color: Colors.white70),
+              title: const Text('Notifications',
+                  style: TextStyle(color: Colors.white)),
+              onTap: () {
+                Navigator.pop(context);
+                // TODO: open notifications
+              },
+            ),
+            ListTile(
+              leading: const Icon(Icons.settings, color: Colors.white70),
+              title:
+                  const Text('Settings', style: TextStyle(color: Colors.white)),
+              onTap: () {
+                Navigator.pop(context);
+                // TODO: open settings
+              },
+            ),
+          ],
+        ),
+      ),
+    ),
+  );
+}

--- a/lib/ui/overlay/widgets/viewer_avatar.dart
+++ b/lib/ui/overlay/widgets/viewer_avatar.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import '../../../session/user_session.dart';
+
+class ViewerAvatar extends StatelessWidget {
+  final double size;
+  final VoidCallback? onTap;
+  const ViewerAvatar({super.key, this.size = 44, this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    return ValueListenableBuilder<UserProfile?>(
+      valueListenable: userSession.current,
+      builder: (_, p, __) {
+        final url = p?.pictureUrl;
+        final initials = _initials(p?.displayName ?? p?.npub ?? '');
+        final bg = _seedColor(p?.npub ?? 'guest');
+
+        final avatar = ClipOval(
+          child: Container(
+            width: size,
+            height: size,
+            color: bg,
+            child: url != null && url.isNotEmpty
+                ? Image.network(
+                    url,
+                    fit: BoxFit.cover,
+                    errorBuilder: (_, __, ___) {
+                      return _fallback(initials);
+                    },
+                  )
+                : _fallback(initials),
+          ),
+        );
+
+        return Material(
+          color: Colors.transparent,
+          child: InkWell(
+            customBorder: const CircleBorder(),
+            onTap: onTap,
+            child: avatar,
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _fallback(String initials) => Center(
+        child: Text(
+          initials,
+          style: const TextStyle(
+            color: Colors.white,
+            fontWeight: FontWeight.w700,
+          ),
+        ),
+      );
+
+  String _initials(String s) {
+    final parts = s.trim().split(RegExp(r'\s+'));
+    if (parts.isEmpty) return 'U';
+    final a = parts.first.isNotEmpty ? parts.first[0] : 'U';
+    final b = parts.length > 1 && parts.last.isNotEmpty ? parts.last[0] : '';
+    return (a + b).toUpperCase();
+  }
+
+  Color _seedColor(String seed) {
+    final h = seed.codeUnits.fold<int>(0, (a, b) => (a + b) & 0xFF);
+    final hue = (h * 3.6) % 360; // 0..360
+    return HSLColor.fromAHSL(1, hue, 0.55, 0.45).toColor();
+  }
+}


### PR DESCRIPTION
## Summary
- show current user's avatar in HUD
- tap avatar to open account menu
- seed user session with placeholder profile

## Testing
- `flutter clean && flutter pub get` *(fails: command not found)*
- `flutter run -d chrome` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a129f1775483319c6656441e699740