### PR TITLE
Reduce vertical footprint by placing counts beside icons, shrinking gaps adaptively, and keeping tap-targets crisp on touch.

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ empty slots.
 - No permissions required; works in PWA too.
 
 ### Action stack
-- **Action stack is viewport-aware**: on short windows the gaps shrink automatically (min gap 6px), labels use a compact size, and the stack sits closer to centre without overlapping the Create button.
-- Buttons use 44 px tap targets with compact spacing and baseline-aligned counts.
+- **Action bar**: counts now sit to the right of icons. Vertical gaps adapt to the viewport (4–10 px). Tap-targets are 44 px on touch, 40 px on mouse.
 - Tooltips appear on web/desktop.
 
 ### Deterministic widget tests for video

--- a/lib/ui/design/tokens.dart
+++ b/lib/ui/design/tokens.dart
@@ -10,12 +10,21 @@ class T {
   static const Color bg = Colors.black;
   static const Color blue = Colors.blueAccent;
 
-  static const double btnSize = 44; // min tap target (kept ≥44px)
-  static const double btnGap = 10; // gap between icon and count
-  static const double stackGapMin = 6; // ↓ new: tighter floor
-  static const double stackGapMax = 14; // cap for tall screens
-  static const double stackSidePad = 20; // right margin
-  static const double stackSafeBottom =
-      140; // space reserved for Create btn footprint
+  // Tap target sizes (we keep ≥44 on touch)
+  static const double btnSizeTouch = 44;
+  static const double btnSizeMouse = 40;
+
+  // Vertical gap between rows (min..max)
+  static const double stackGapMin = 4;
+  static const double stackGapMed = 6;
+  static const double stackGapMax = 10;
+
+  // Spacing inside a row (icon ↔ count)
+  static const double rowGap = 6;
+
+  static const double stackSidePad = 18;
+  static const double stackTopHeadroom = 80;
+  static const double stackBottomReserve =
+      120; // Create button footprint
   static const double maxCaptionW = 520; // used elsewhere
 }

--- a/lib/ui/home/widgets/overlay_cluster.dart
+++ b/lib/ui/home/widgets/overlay_cluster.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-
 import '../../design/tokens.dart';
 import '../../overlay/widgets/action_button.dart';
 
@@ -32,83 +31,39 @@ class OverlayCluster extends StatelessWidget {
     required this.zapCount,
   });
 
+  double _gapForHeight(double h) {
+    if (h < 560) return T.stackGapMin; // very tight
+    if (h < 720) return T.stackGapMed; // tight
+    return T.stackGapMax; // comfy
+  }
+
   @override
   Widget build(BuildContext context) {
-    return LayoutBuilder(
-      builder: (ctx, constraints) {
-        // Available vertical space for the column. We reserve a little
-        // headroom so it never kisses top/bottom chrome.
-        final avail = constraints.maxHeight.clamp(200.0, 1200.0);
+    return LayoutBuilder(builder: (_, c) {
+      final gap = _gapForHeight(c.maxHeight);
 
-        // Estimate height of rows that show a numeric label vs. icon only.
-        const labelLine = 11.0; // labelSmall font size with height 1.0
-        const rowWithLabel = T.btnSize + T.btnGap + labelLine; // icon+gap+label
-        const rowNoLabel = T.btnSize;
+      Widget row(String icon, String? count, VoidCallback onTap, String tip) =>
+          Padding(
+            padding: EdgeInsets.only(bottom: gap),
+            child: ActionButton(icon: icon, label: count, onTap: onTap, tooltip: tip),
+          );
 
-        // Six actions, one of which (bookmark) has no label.
-        const labelledRows = 5;
-        const noLabelRows = 1;
-        const spacers = 6 - 1;
-        final rowsHeight =
-            labelledRows * rowWithLabel + noLabelRows * rowNoLabel;
-
-        // Ideal free space to distribute as gaps.
-        final free = avail - rowsHeight;
-        double gap;
-        if (free <= 0) {
-          gap = T.stackGapMin;
-        } else {
-          final ideal = free / spacers;
-          gap = ideal.clamp(T.stackGapMin, T.stackGapMax);
-        }
-
-        return Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ActionButton(
-              icon: 'heart_24',
-              label: likeCount,
-              onTap: onLike,
-              tooltip: 'Like',
-            ),
-            SizedBox(height: gap),
-            ActionButton(
-              icon: 'comment_24',
-              label: commentCount,
-              onTap: onComment,
-              tooltip: 'Comments',
-            ),
-            SizedBox(height: gap),
-            ActionButton(
-              icon: 'repost_24',
-              label: repostCount,
-              onTap: onRepost,
-              tooltip: 'Repost',
-            ),
-            SizedBox(height: gap),
-            ActionButton(
-              icon: 'bookmark_24',
-              label: null,
-              onTap: onCopyLink,
-              tooltip: 'Save',
-            ),
-            SizedBox(height: gap),
-            ActionButton(
-              icon: 'share_24',
-              label: shareCount,
-              onTap: onShare,
-              tooltip: 'Share',
-            ),
-            SizedBox(height: gap),
-            ActionButton(
-              icon: 'zap_24',
-              label: zapCount,
-              onTap: onZap,
-              tooltip: 'Zap',
-            ),
-          ],
-        );
-      },
-    );
+      return Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          row('heart_24',    likeCount,    onLike,    'Like'),
+          row('comment_24',  commentCount, onComment, 'Comments'),
+          row('repost_24',   repostCount,  onRepost,  'Repost'),
+          row('bookmark_24', null,         onCopyLink,'Save'),
+          row('share_24',    shareCount,   onShare,   'Share'),
+          Padding(
+            padding: EdgeInsets.only(bottom: 0), // last item no extra gap
+            child: ActionButton(icon: 'zap_24', label: zapCount, onTap: onZap, tooltip: 'Zap'),
+          ),
+        ],
+      );
+    });
   }
 }
+

--- a/lib/ui/overlay/hud_overlay.dart
+++ b/lib/ui/overlay/hud_overlay.dart
@@ -149,47 +149,37 @@ class HudOverlay extends StatelessWidget {
                                   ),
                                 ),
                               ),
-                            Builder(
-                              builder: (ctx) {
-                                final s = MediaQuery.of(ctx).size;
-                                final safeBottom = MediaQuery.of(
-                                  ctx,
-                                ).padding.bottom;
-                                final bottom = (s.height * 0.22 + safeBottom)
-                                    .clamp(
-                                      100.0,
-                                      T.stackSafeBottom,
-                                    ); // keep it tighter
-                                return Positioned(
-                                  right: T.stackSidePad,
-                                  bottom: bottom,
-                                  child: ConstrainedBox(
-                                    constraints: BoxConstraints(
-                                      // give the LayoutBuilder a clean vertical budget
-                                      maxHeight:
-                                          s.height -
-                                          bottom -
-                                          20, // reserve a sliver of top headroom
-                                    ),
-                                    child: OverlayCluster(
-                                      onLike: onLikeLogical,
-                                      onComment: () {},
-                                      onRepost: () {},
-                                      onShare: onShareLogical ?? () {},
-                                      onCopyLink: () {},
-                                      onZap: () {},
-                                      likeCount: state.model.value.likeCount,
-                                      commentCount:
-                                          state.model.value.commentCount,
-                                      repostCount:
-                                          state.model.value.repostCount,
-                                      shareCount: state.model.value.shareCount,
-                                      zapCount: state.model.value.zapCount,
-                                    ),
+                            Builder(builder: (ctx) {
+                              final s = MediaQuery.of(ctx).size;
+                              final bottom = (s.height * 0.18 +
+                                      MediaQuery.of(ctx).padding.bottom)
+                                  .clamp(80.0, T.stackBottomReserve);
+                              return Positioned(
+                                right: T.stackSidePad,
+                                bottom: bottom,
+                                child: ConstrainedBox(
+                                  constraints: BoxConstraints(
+                                    maxHeight:
+                                        s.height - bottom - T.stackTopHeadroom,
                                   ),
-                                );
-                              },
-                            ),
+                                  child: OverlayCluster(
+                                    onLike: onLikeLogical,
+                                    onComment: () {},
+                                    onRepost: () {},
+                                    onShare: onShareLogical ?? () {},
+                                    onCopyLink: () {},
+                                    onZap: () {},
+                                    likeCount: state.model.value.likeCount,
+                                    commentCount:
+                                        state.model.value.commentCount,
+                                    repostCount:
+                                        state.model.value.repostCount,
+                                    shareCount: state.model.value.shareCount,
+                                    zapCount: state.model.value.zapCount,
+                                  ),
+                                ),
+                              );
+                            }),
                             Positioned(
                               left: T.s24,
                               bottom: MediaQuery.of(context).size.height * 0.22,

--- a/lib/ui/overlay/widgets/action_button.dart
+++ b/lib/ui/overlay/widgets/action_button.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-
 import '../../design/tokens.dart';
 import '../../widgets/app_icon.dart';
 
@@ -20,47 +19,55 @@ class ActionButton extends StatelessWidget {
     this.color = Colors.white,
   });
 
+  double _btnSize(BuildContext context) {
+    // On the web with a mouse, allow 40px; otherwise 44px for touch.
+    final kind = RendererBinding.instance.mouseTracker.mouseIsConnected;
+    return kind ? T.btnSizeMouse : T.btnSizeTouch;
+  }
+
   @override
   Widget build(BuildContext context) {
-    final core = Column(
+    final size = _btnSize(context);
+
+    final core = Row(
       mainAxisSize: MainAxisSize.min,
       crossAxisAlignment: CrossAxisAlignment.center,
       children: [
         InkResponse(
           onTap: onTap,
-          radius: T.btnSize / 2,
+          radius: size / 2,
           child: SizedBox(
-            width: T.btnSize,
-            height: T.btnSize,
+            width: size,
+            height: size,
             child: Center(child: AppIcon(icon, size: 24, color: color)),
           ),
         ),
         if (label != null) ...[
-          const SizedBox(height: T.btnGap),
-          Text(
-            label!,
-            textAlign: TextAlign.center,
-            maxLines: 1,
-            overflow: TextOverflow.ellipsis,
-            style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                  fontSize: 11,
-                  height: 1.0,
-                  color: color.withValues(alpha: 0.85),
-                  fontWeight: FontWeight.w600,
-                  letterSpacing: 0.15,
-                ),
+          const SizedBox(width: T.rowGap),
+          ConstrainedBox(
+            constraints: const BoxConstraints(minWidth: 24),
+            child: Text(
+              label!,
+              maxLines: 1,
+              overflow: TextOverflow.fade,
+              softWrap: false,
+              textAlign: TextAlign.left,
+              style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    fontSize: 11,
+                    height: 1.0,
+                    color: color.withOpacity(0.9),
+                    fontWeight: FontWeight.w600,
+                    letterSpacing: 0.1,
+                  ),
+            ),
           ),
         ],
       ],
     );
 
-    // Tooltips are most useful on web/desktop.
-    return kIsWeb && tooltip != null
-        ? Tooltip(
-            message: tooltip!,
-            waitDuration: const Duration(milliseconds: 300),
-            child: core,
-          )
+    return (kIsWeb && tooltip != null)
+        ? Tooltip(message: tooltip!, child: core)
         : core;
   }
 }
+

--- a/lib/ui/overlay/widgets/action_button.dart
+++ b/lib/ui/overlay/widgets/action_button.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import '../../design/tokens.dart';
 import '../../widgets/app_icon.dart';
 
@@ -55,7 +56,7 @@ class ActionButton extends StatelessWidget {
               style: Theme.of(context).textTheme.labelSmall?.copyWith(
                     fontSize: 11,
                     height: 1.0,
-                    color: color.withOpacity(0.9),
+                    color: color.withValues(alpha: 0.9),
                     fontWeight: FontWeight.w600,
                     letterSpacing: 0.1,
                   ),

--- a/test/ui/action_bar_ultracompact_test.dart
+++ b/test/ui/action_bar_ultracompact_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:nostr_video/ui/home/home_page.dart';
+
+void main() {
+  testWidgets(
+      'ultra-compact action bar stays < 320px high on 768px tall view',
+      (t) async {
+    await t.binding.setSurfaceSize(const Size(1024, 768));
+    await t.pumpWidget(const MaterialApp(home: HomePage()));
+    await t.pumpAndSettle();
+
+    // Use the Like tooltip proxy to locate the column root.
+    final like = find.byTooltip('Like');
+    expect(like, findsOneWidget);
+
+    // Just a smoke assertion that we didn't overflow and are roughly compact.
+    // (Goldens can be added later.)
+  });
+}

--- a/test/ui/action_bar_ultracompact_test.dart
+++ b/test/ui/action_bar_ultracompact_test.dart
@@ -1,20 +1,27 @@
-import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:network_image_mock/network_image_mock.dart';
 import 'package:nostr_video/ui/home/home_page.dart';
+import 'package:nostr_video/ui/home/widgets/overlay_cluster.dart';
+import '../test_helpers/test_video_scope.dart';
 
 void main() {
   testWidgets(
       'ultra-compact action bar stays < 320px high on 768px tall view',
       (t) async {
     await t.binding.setSurfaceSize(const Size(1024, 768));
-    await t.pumpWidget(const MaterialApp(home: HomePage()));
-    await t.pumpAndSettle();
+    await mockNetworkImagesFor(() async {
+      await t
+          .pumpWidget(const TestVideoApp(child: MaterialApp(home: HomePage())));
+      await t.pumpAndSettle();
+    });
 
     // Use the Like tooltip proxy to locate the column root.
     final like = find.byTooltip('Like');
     expect(like, findsOneWidget);
-
-    // Just a smoke assertion that we didn't overflow and are roughly compact.
-    // (Goldens can be added later.)
+    final cluster =
+        find.ancestor(of: like, matching: find.byType(OverlayCluster));
+    expect(cluster, findsOneWidget);
+    expect(t.getSize(cluster).height, lessThan(320));
   });
 }

--- a/test/ui/action_bar_ultracompact_test.dart
+++ b/test/ui/action_bar_ultracompact_test.dart
@@ -11,16 +11,13 @@ void main() {
       (t) async {
     await t.binding.setSurfaceSize(const Size(1024, 768));
     await mockNetworkImagesFor(() async {
-      await t
-          .pumpWidget(const TestVideoApp(child: MaterialApp(home: HomePage())));
+      await t.pumpWidget(
+          const TestVideoApp(child: MaterialApp(home: HomePage())));
       await t.pumpAndSettle();
     });
 
-    // Use the Like tooltip proxy to locate the column root.
-    final like = find.byTooltip('Like');
-    expect(like, findsOneWidget);
-    final cluster =
-        find.ancestor(of: like, matching: find.byType(OverlayCluster));
+    // Locate the action cluster directly and confirm it stays compact.
+    final cluster = find.byType(OverlayCluster);
     expect(cluster, findsOneWidget);
     expect(t.getSize(cluster).height, lessThan(320));
   });


### PR DESCRIPTION
## Summary
- Expose touch and mouse tap targets plus adaptive stack spacing in design tokens
- Switch action buttons to a horizontal layout with side counts
- Rework overlay cluster for viewport-based gaps and side-aligned rows
- Tighten HUD overlay anchoring and stack budget
- Add smoke test verifying compact action bar layout
- Document action bar behavior in README

## Testing
- `flutter test test/ui/action_bar_ultracompact_test.dart` *(fails: command not found)*
- `dart test test/ui/action_bar_ultracompact_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a15b4228b4833198b8298a518eecd2