### PR TITLE
alpha(core): Nostr-first source switch; web HLS flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,10 @@ Acceptance
 - Using Copy Link copies a URL that re-opens to the same item.
 
 ### Nostr (read-only) adapter
-- Enable via build flag:  
+- Enable via build flag:
   `flutter run -d chrome --dart-define=NOSTR_ENABLED=true`
+- Prefer web HLS (default true):
+  `flutter run -d chrome --dart-define=WEB_HLS_PREFERRED=true`
 - Edit default relays in `lib/config/app_config.dart`.
 - We subscribe to recent kind-1 notes and try to extract a playable video URL
   from tags `["video" | "media", "<url>"]` or the first `mp4/webm/m3u8` link in content.
@@ -145,6 +147,7 @@ Commands
 - flutter clean && flutter pub get
 - flutter test
 - flutter run -d chrome --dart-define=NOSTR_ENABLED=true
+- flutter run -d chrome --dart-define=WEB_HLS_PREFERRED=true
 
 Acceptance
 - With flag OFF, the demo feed behaves as before.

--- a/lib/config/app_config.dart
+++ b/lib/config/app_config.dart
@@ -1,10 +1,4 @@
-import 'package:flutter/foundation.dart'; // ignore: unused_import
-
-/// Build flag: flutter run -d chrome --dart-define=NOSTR_ENABLED=true
-const bool kNostrEnabled = bool.fromEnvironment(
-  'NOSTR_ENABLED',
-  defaultValue: false,
-);
+// Configuration values for Nostr networking.
 
 // Add more relays (websocket friendly)
 const List<String> kDefaultRelays = <String>[

--- a/lib/core/config/app_config.dart
+++ b/lib/core/config/app_config.dart
@@ -1,0 +1,9 @@
+class AppConfig {
+  // Enable real Nostr backend
+  static const bool nostrEnabled =
+      bool.fromEnvironment('NOSTR_ENABLED', defaultValue: false);
+
+  // Prefer the web HLS path if available (safe fallback guards included)
+  static const bool webHlsPreferred =
+      bool.fromEnvironment('WEB_HLS_PREFERRED', defaultValue: true);
+}

--- a/lib/data/source_selector.dart
+++ b/lib/data/source_selector.dart
@@ -1,0 +1,23 @@
+import 'dart:developer' as dev;
+
+import '../core/config/app_config.dart';
+import '../feed/data_source.dart';
+
+class SourceSelector {
+  static FeedDataSource? _instance;
+
+  static FeedDataSource get instance => _instance ??= _create();
+
+  static void bootstrap() {
+    _instance = _create();
+  }
+
+  static FeedDataSource _create() {
+    if (AppConfig.nostrEnabled) {
+      dev.log('[ShortLived] Data source: NOSTR', name: 'ShortLived');
+      return NostrFeedDataSource();
+    }
+    dev.log('[ShortLived] Data source: DEMO', name: 'ShortLived');
+    return DemoFeedDataSource();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'app.dart';
 import 'video/video_adapter.dart';
 import 'video/video_adapter_real.dart';
 import 'session/user_session.dart';
+import 'data/source_selector.dart';
 
 // Conditional import: on web use the real implementation, elsewhere the stub.
 import 'util/sw_debug_stub.dart'
@@ -17,10 +18,6 @@ Future<void> main() async {
     WidgetsFlutterBinding.ensureInitialized();
     FlutterError.onError =
         (details) => FlutterError.dumpErrorToConsole(details);
-
-    const nostr = bool.fromEnvironment('NOSTR_ENABLED', defaultValue: false);
-    // ignore: avoid_print
-    print('[ShortLived] NOSTR_ENABLED=$nostr');
 
     // In debug on web, unregister stale service workers and caches.
     assert(() {
@@ -37,6 +34,9 @@ Future<void> main() async {
       displayName: 'You',
       pictureUrl: null,
     );
+
+    // Select primary data source before app builds.
+    SourceSelector.bootstrap();
 
     runApp(VideoScope(adapter: RealVideoAdapter(), child: const App()));
   }, (Object error, StackTrace stack) {

--- a/lib/video/video_adapter_real.dart
+++ b/lib/video/video_adapter_real.dart
@@ -5,6 +5,7 @@ import 'package:video_player/video_player.dart';
 import '../ui/home/widgets/unsupported_overlay.dart';
 import 'web_video_compat.dart';
 import 'video_adapter.dart';
+import '../core/config/app_config.dart';
 
 class RealVideoAdapter extends VideoAdapter {
   @override
@@ -83,6 +84,11 @@ class _RealVideoState extends State<_RealVideo> {
 
   Future<void> _init() async {
     final url = widget.url;
+    if (kIsWeb && url.endsWith('.m3u8') && !AppConfig.webHlsPreferred) {
+      widget.onUnsupported?.call('HLS disabled by flag');
+      _safeSetState(() => _error = true);
+      return;
+    }
     if (!WebVideoCompat.browserCanLikelyPlay(url)) {
       widget.onUnsupported?.call('Codec not supported by this browser');
       _safeSetState(() => _error = true);
@@ -138,7 +144,7 @@ class _RealVideoState extends State<_RealVideo> {
         return;
       }
       await local.dispose();
-      widget.onUnsupported?.call(e.toString());
+      widget.onUnsupported?.call('Video init error: $e');
       _safeSetState(() => _error = true);
     }
   }


### PR DESCRIPTION
## Summary
- centralize `NOSTR_ENABLED` and `WEB_HLS_PREFERRED` via `AppConfig`
- bootstrap feed source selection before app start
- allow disabling web HLS via `WEB_HLS_PREFERRED` in the real video adapter
- document new flags in README

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a196ec8a108331adb51d0abe2788fa