### PR TITLE
ui: refine overlay layout and center create

### DIFF
--- a/lib/ui/home/home_page.dart
+++ b/lib/ui/home/home_page.dart
@@ -255,7 +255,8 @@ class _HomePageState extends State<HomePage> with RouteAware {
           child: const CreateButton(),
         ),
       ),
-      floatingActionButtonLocation: FloatingActionButtonLocation.endFloat,
+      // Center the create button so drawers and rails don't shift it.
+      floatingActionButtonLocation: FloatingActionButtonLocation.centerFloat,
     );
   }
 }

--- a/lib/ui/home/widgets/create_button.dart
+++ b/lib/ui/home/widgets/create_button.dart
@@ -6,26 +6,28 @@ class CreateButton extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      children: [
-        Container(
-          width: 56,
-          height: 56,
-          decoration: BoxDecoration(
-            borderRadius: BorderRadius.circular(28),
-            border: Border.all(
-              color: Colors.white.withValues(alpha: 0.85),
-              width: 2,
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Container(
+            width: 56,
+            height: 56,
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(28),
+              border: Border.all(
+                color: Colors.white.withValues(alpha: 0.85),
+                width: 2,
+              ),
             ),
           ),
-        ),
-        const SizedBox(height: 8),
-        const Text(
-          'Create',
-          style: TextStyle(color: Colors.white),
-        ),
-      ],
+          const SizedBox(height: 8),
+          const Text(
+            'Create',
+            style: TextStyle(color: Colors.white),
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/ui/home/widgets/overlay_cluster.dart
+++ b/lib/ui/home/widgets/overlay_cluster.dart
@@ -45,23 +45,42 @@ class OverlayCluster extends StatelessWidget {
       Widget row(String icon, String? count, VoidCallback onTap, String tip) =>
           Padding(
             padding: EdgeInsets.only(bottom: gap),
-            child: ActionButton(icon: icon, label: count, onTap: onTap, tooltip: tip),
+            child: Align(
+              alignment: Alignment.centerRight,
+              child: ActionButton(
+                icon: icon,
+                label: count,
+                onTap: onTap,
+                tooltip: tip,
+              ),
+            ),
           );
 
-      return Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.end,
-        children: [
-          row('heart_24',    likeCount,    onLike,    'Like'),
-          row('comment_24',  commentCount, onComment, 'Comments'),
-          row('repost_24',   repostCount,  onRepost,  'Repost'),
-          row('bookmark_24', null,         onCopyLink,'Save'),
-          row('share_24',    shareCount,   onShare,   'Share'),
-          Padding(
-            padding: EdgeInsets.only(bottom: 0), // last item no extra gap
-            child: ActionButton(icon: 'zap_24', label: zapCount, onTap: onZap, tooltip: 'Zap'),
-          ),
-        ],
+      return SizedBox(
+        width: 56,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.end,
+          children: [
+            row('heart_24',    likeCount,    onLike,    'Like'),
+            row('comment_24',  commentCount, onComment, 'Comments'),
+            row('repost_24',   repostCount,  onRepost,  'Repost'),
+            row('bookmark_24', null,         onCopyLink,'Save'),
+            row('share_24',    shareCount,   onShare,   'Share'),
+            Padding(
+              padding: EdgeInsets.only(bottom: 0), // last item no extra gap
+              child: Align(
+                alignment: Alignment.centerRight,
+                child: ActionButton(
+                  icon: 'zap_24',
+                  label: zapCount,
+                  onTap: onZap,
+                  tooltip: 'Zap',
+                ),
+              ),
+            ),
+          ],
+        ),
       );
     });
   }

--- a/lib/ui/overlay/hud_overlay.dart
+++ b/lib/ui/overlay/hud_overlay.dart
@@ -121,19 +121,20 @@ class HudOverlay extends StatelessWidget {
                     duration: const Duration(milliseconds: 150),
                     child: Material(
                       type: MaterialType.transparency,
-                      child: SafeArea(
-                        child: Stack(
+                      child: Builder(builder: (context) {
+                        final padding = MediaQuery.of(context).padding;
+                        return Stack(
                           children: [
                             Positioned(
-                              left: T.s24,
-                              top: T.s24,
+                              left: T.s24 + padding.left,
+                              top: T.s24 + padding.top,
                               child: SearchPill(
                                 onTap: () => _openSearch(context),
                               ),
                             ),
                             Positioned(
-                              right: T.s24,
-                              top: T.s24,
+                              right: T.s24 + padding.right,
+                              top: T.s24 + padding.top,
                               child: const SizedBox(
                                 width: 48,
                                 height: 48,
@@ -142,8 +143,8 @@ class HudOverlay extends StatelessWidget {
                             ),
                             if (kIsWeb)
                               Positioned(
-                                left: T.s24,
-                                top: T.s24 + 56,
+                                left: T.s24 + padding.left,
+                                top: T.s24 + padding.top + 56,
                                 child: ValueListenableBuilder<bool>(
                                   valueListenable: controller.muted,
                                   builder: (_, muted, __) => ElevatedButton(
@@ -158,7 +159,7 @@ class HudOverlay extends StatelessWidget {
                                       MediaQuery.of(ctx).padding.bottom)
                                   .clamp(80.0, T.stackBottomReserve);
                               return Positioned(
-                                right: T.stackSidePad,
+                                right: T.stackSidePad + padding.right,
                                 bottom: bottom,
                                 child: ConstrainedBox(
                                   constraints: BoxConstraints(
@@ -184,22 +185,22 @@ class HudOverlay extends StatelessWidget {
                               );
                             }),
                             Positioned(
-                              left: T.s24,
-                              bottom: MediaQuery.of(context).size.height * 0.22,
+                              left: T.s24 + padding.left,
+                              bottom: MediaQuery.of(context).size.height * 0.22 +
+                                  padding.bottom,
                               child: ValueListenableBuilder<HudModel>(
                                 valueListenable: state.model,
                                 builder: (_, m, __) => BottomInfoBar(model: m),
                               ),
                             ),
                             Positioned(
-                              right: 16,
-                              bottom:
-                                  16 + MediaQuery.of(context).padding.bottom,
+                              right: 16 + padding.right,
+                              bottom: 16 + padding.bottom,
                               child: const ViewerAvatar(),
                             ),
                           ],
-                        ),
-                      ),
+                        );
+                      }),
                     ),
                   ),
                 );

--- a/lib/ui/overlay/widgets/action_button.dart
+++ b/lib/ui/overlay/widgets/action_button.dart
@@ -45,14 +45,14 @@ class ActionButton extends StatelessWidget {
         ),
         if (label != null) ...[
           const SizedBox(width: T.rowGap),
-          ConstrainedBox(
-            constraints: const BoxConstraints(minWidth: 24),
+          SizedBox(
+            width: 28,
             child: Text(
               label!,
               maxLines: 1,
               overflow: TextOverflow.fade,
               softWrap: false,
-              textAlign: TextAlign.left,
+              textAlign: TextAlign.right,
               style: Theme.of(context).textTheme.labelSmall?.copyWith(
                     fontSize: 11,
                     height: 1.0,

--- a/lib/ui/overlay/widgets/bottom_info_bar.dart
+++ b/lib/ui/overlay/widgets/bottom_info_bar.dart
@@ -15,7 +15,8 @@ class BottomInfoBar extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final size = MediaQuery.of(context).size;
-    final maxW = min(size.width * 0.78, 520.0);
+    // Clamp width so captions can't push the overlay layout.
+    final maxW = min(size.width * 0.66, 520.0);
     final showMore = model.fullCaption.trim() != model.caption.trim();
 
     return ConstrainedBox(


### PR DESCRIPTION
## Summary
- center create button to keep it clear of rails and drawers
- remove global SafeArea, use directional padding for overlay items
- right-align action rail items and clamp caption width

## Testing
- `dart format lib/ui/home/home_page.dart lib/ui/home/widgets/create_button.dart lib/ui/overlay/hud_overlay.dart lib/ui/home/widgets/overlay_cluster.dart lib/ui/overlay/widgets/action_button.dart lib/ui/overlay/widgets/bottom_info_bar.dart` *(fails: command not found)*
- `dart test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a199cf58a0833195d20a366968faea