### PR TITLE
video(core): robust lifecycle and mute persistence

### DIFF
--- a/lib/nostr/nostr_repo_ws.dart
+++ b/lib/nostr/nostr_repo_ws.dart
@@ -21,39 +21,46 @@ class NostrRepoWebSocket implements NostrRepo {
         final ch = WebSocketChannel.connect(Uri.parse(url));
         _channels.add(ch);
 
-        final subId = 'shortlived_${DateTime.now().millisecondsSinceEpoch}_${_channels.length}';
+        // Listen for frames and errors before issuing any commands so
+        // handshake failures don't bubble as uncaught zone errors.
+        final sub = ch.stream.listen(
+          (raw) {
+            try {
+              final msg = jsonDecode(raw as String);
+              if (msg is List && msg.isNotEmpty) {
+                final typ = msg[0] as String;
+                if (typ == 'EVENT' && msg.length >= 3) {
+                  final ev = msg[2] as Map<String, dynamic>;
+                  final e = NostrEvent(
+                    id: ev['id'] as String,
+                    pubkey: ev['pubkey'] as String,
+                    createdAt: (ev['created_at'] as num).toInt(),
+                    kind: (ev['kind'] as num).toInt(),
+                    content: (ev['content'] ?? '') as String,
+                    tags: (ev['tags'] as List<dynamic>?)
+                            ?.map((x) => (x as List).map((e) => e).toList())
+                            .toList() ??
+                        const <List<dynamic>>[],
+                  );
+                  _controller.add(e);
+                }
+              }
+            } catch (_) {
+              // swallow malformed frames
+            }
+          },
+          onError: (_) {},
+          onDone: () {},
+        );
+        _subs.add(sub);
+
+        final subId =
+            'shortlived_${DateTime.now().millisecondsSinceEpoch}_${_channels.length}';
         final filter = {
           'kinds': [1],
           'limit': useLimit,
         };
         ch.sink.add(jsonEncode(['REQ', subId, filter]));
-
-        final sub = ch.stream.listen((raw) {
-          try {
-            final msg = jsonDecode(raw as String);
-            if (msg is List && msg.isNotEmpty) {
-              final typ = msg[0] as String;
-              if (typ == 'EVENT' && msg.length >= 3) {
-                final ev = msg[2] as Map<String, dynamic>;
-                final e = NostrEvent(
-                  id: ev['id'] as String,
-                  pubkey: ev['pubkey'] as String,
-                  createdAt: (ev['created_at'] as num).toInt(),
-                  kind: (ev['kind'] as num).toInt(),
-                  content: (ev['content'] ?? '') as String,
-                  tags: (ev['tags'] as List<dynamic>?)
-                          ?.map((x) => (x as List).map((e) => e).toList())
-                          .toList() ??
-                      const <List<dynamic>>[],
-                );
-                _controller.add(e);
-              }
-            }
-          } catch (_) {
-            // swallow malformed frames
-          }
-        }, onError: (_) {}, onDone: () {});
-        _subs.add(sub);
       } catch (_) {
         // ignore bad relay
       }

--- a/lib/ui/home/home_page.dart
+++ b/lib/ui/home/home_page.dart
@@ -17,6 +17,7 @@ import '../../web/url_shim.dart'
 import '../../utils/count_format.dart';
 import '../../utils/caption_format.dart';
 import '../../platform/share/share.dart';
+import '../../utils/prefs.dart';
 
 class HomePage extends StatefulWidget {
   const HomePage({super.key});
@@ -64,6 +65,12 @@ class _HomePageState extends State<HomePage> with RouteAware {
   @override
   void initState() {
     super.initState();
+    VideoPrefs.getMuted().then((m) {
+      _controller.muted.value = m;
+    });
+    _controller.muted.addListener(() {
+      VideoPrefs.setMuted(_controller.muted.value);
+    });
     // Deep link (v/id) against current list (will re-map after data arrives)
     final uri = urlShim.current();
     final id = uri.queryParameters['id'];

--- a/lib/ui/home/widgets/overlay_cluster.dart
+++ b/lib/ui/home/widgets/overlay_cluster.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../../design/tokens.dart';
 import '../../overlay/widgets/action_button.dart';
+import '../../../utils/capabilities.dart';
 
 class OverlayCluster extends StatelessWidget {
   final VoidCallback onLike;
@@ -48,20 +49,22 @@ class OverlayCluster extends StatelessWidget {
             child: ActionButton(icon: icon, label: count, onTap: onTap, tooltip: tip),
           );
 
+      final children = <Widget>[
+        row('heart_24',    likeCount,    onLike,    'Like'),
+        row('comment_24',  commentCount, onComment, 'Comments'),
+        row('repost_24',   repostCount,  onRepost,  'Repost'),
+        row('bookmark_24', null,         onCopyLink,'Save'),
+        if (Capabilities.shareSupported)
+          row('share_24',    shareCount,   onShare,   'Share'),
+        Padding(
+          padding: EdgeInsets.only(bottom: 0), // last item no extra gap
+          child: ActionButton(icon: 'zap_24', label: zapCount, onTap: onZap, tooltip: 'Zap'),
+        ),
+      ];
       return Column(
         mainAxisSize: MainAxisSize.min,
         crossAxisAlignment: CrossAxisAlignment.end,
-        children: [
-          row('heart_24',    likeCount,    onLike,    'Like'),
-          row('comment_24',  commentCount, onComment, 'Comments'),
-          row('repost_24',   repostCount,  onRepost,  'Repost'),
-          row('bookmark_24', null,         onCopyLink,'Save'),
-          row('share_24',    shareCount,   onShare,   'Share'),
-          Padding(
-            padding: EdgeInsets.only(bottom: 0), // last item no extra gap
-            child: ActionButton(icon: 'zap_24', label: zapCount, onTap: onZap, tooltip: 'Zap'),
-          ),
-        ],
+        children: children,
       );
     });
   }

--- a/lib/ui/widgets/video_tile.dart
+++ b/lib/ui/widgets/video_tile.dart
@@ -97,7 +97,7 @@ class _ErrorOverlay extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      color: Colors.black.withOpacity(0.35),
+      color: Colors.black.withValues(alpha: 0.35),
       child: Center(
         child: Column(
           mainAxisSize: MainAxisSize.min,

--- a/lib/ui/widgets/video_tile.dart
+++ b/lib/ui/widgets/video_tile.dart
@@ -1,0 +1,113 @@
+import 'package:flutter/material.dart';
+import 'package:video_player/video_player.dart';
+import 'package:visibility_detector/visibility_detector.dart';
+import '../../video/video_lifecycle.dart';
+
+typedef OnPrefetch = Future<void> Function();
+
+class VideoTile extends StatefulWidget {
+  const VideoTile({
+    super.key,
+    required this.lifecycle,
+    required this.onPrefetchNext,
+  });
+  final VideoLifecycle lifecycle;
+  final OnPrefetch onPrefetchNext;
+  @override
+  State<VideoTile> createState() => _VideoTileState();
+}
+
+class _VideoTileState extends State<VideoTile> {
+  bool _error = false;
+  bool _loading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    final c = widget.lifecycle.controller;
+    _loading = !(c?.value.isInitialized ?? false);
+    c?.addListener(_onControllerChanged);
+    if (c != null && c.value.isInitialized) {
+      widget.onPrefetchNext();
+    }
+  }
+
+  void _onControllerChanged() {
+    final c = widget.lifecycle.controller!;
+    final v = c.value;
+    if (!mounted) return;
+    setState(() {
+      _loading = !v.isInitialized;
+      _error = v.hasError;
+    });
+    if (v.isInitialized) {
+      widget.onPrefetchNext();
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.lifecycle.controller?.removeListener(_onControllerChanged);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final ctrl = widget.lifecycle.controller;
+    return VisibilityDetector(
+      key: const Key('video-visibility'),
+      onVisibilityChanged: (info) {
+        final vis = info.visibleFraction;
+        final c = widget.lifecycle.controller;
+        if (c == null) return;
+        if (vis < 0.15) {
+          c.pause();
+        } else if (vis > 0.5 && c.value.isInitialized && !c.value.isPlaying) {
+          c.play();
+        }
+      },
+      child: Stack(
+        fit: StackFit.expand,
+        children: [
+          if (ctrl != null && ctrl.value.isInitialized)
+            FittedBox(
+              fit: BoxFit.cover,
+              child: SizedBox(
+                width: ctrl.value.size.width,
+                height: ctrl.value.size.height,
+                child: VideoPlayer(ctrl),
+              ),
+            ),
+          if (_loading)
+            const Center(child: CircularProgressIndicator()),
+          if (_error)
+            _ErrorOverlay(onRetry: () async {
+              setState(() => _loading = true);
+              await widget.lifecycle.retry();
+            }),
+        ],
+      ),
+    );
+  }
+}
+
+class _ErrorOverlay extends StatelessWidget {
+  const _ErrorOverlay({required this.onRetry});
+  final VoidCallback onRetry;
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      color: Colors.black.withOpacity(0.35),
+      child: Center(
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text('Video failed to play', style: TextStyle(fontSize: 16)),
+            const SizedBox(height: 12),
+            ElevatedButton(onPressed: onRetry, child: const Text('Retry')),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/utils/capabilities.dart
+++ b/lib/utils/capabilities.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/foundation.dart';
+// ignore: avoid_web_libraries_in_flutter
+import 'dart:html' as html show Navigator, window;
+
+class Capabilities {
+  static bool get shareSupported {
+    if (!kIsWeb) return false;
+    try {
+      final nav = html.window.navigator as dynamic;
+      return nav != null && nav.canShare != null;
+    } catch (_) {
+      return false;
+    }
+  }
+}

--- a/lib/utils/capabilities.dart
+++ b/lib/utils/capabilities.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/foundation.dart';
-// ignore: avoid_web_libraries_in_flutter
-import 'dart:html' as html show Navigator, window;
+import 'package:web/web.dart' as html;
 
 class Capabilities {
   static bool get shareSupported {

--- a/lib/utils/capabilities.dart
+++ b/lib/utils/capabilities.dart
@@ -1,15 +1,6 @@
-import 'package:flutter/foundation.dart';
-// ignore: avoid_web_libraries_in_flutter, deprecated_member_use
-import 'dart:html' as html;
+import 'capabilities_io.dart'
+    if (dart.library.html) 'capabilities_web.dart' as impl;
 
 class Capabilities {
-  static bool get shareSupported {
-    if (!kIsWeb) return false;
-    try {
-      final nav = html.window.navigator as dynamic;
-      return nav != null && nav.canShare != null;
-    } catch (_) {
-      return false;
-    }
-  }
+  static bool get shareSupported => impl.shareSupported;
 }

--- a/lib/utils/capabilities.dart
+++ b/lib/utils/capabilities.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
-import 'package:web/web.dart' as html;
+// ignore: avoid_web_libraries_in_flutter, deprecated_member_use
+import 'dart:html' as html;
 
 class Capabilities {
   static bool get shareSupported {

--- a/lib/utils/capabilities_io.dart
+++ b/lib/utils/capabilities_io.dart
@@ -1,0 +1,1 @@
+bool get shareSupported => false;

--- a/lib/utils/capabilities_web.dart
+++ b/lib/utils/capabilities_web.dart
@@ -1,0 +1,10 @@
+import 'dart:html' as html;
+
+bool get shareSupported {
+  try {
+    final nav = html.window.navigator as dynamic;
+    return nav != null && nav.canShare != null;
+  } catch (_) {
+    return false;
+  }
+}

--- a/lib/utils/capabilities_web.dart
+++ b/lib/utils/capabilities_web.dart
@@ -1,3 +1,5 @@
+// ignore_for_file: deprecated_member_use, avoid_web_libraries_in_flutter
+
 import 'dart:html' as html;
 
 bool get shareSupported {

--- a/lib/utils/prefs.dart
+++ b/lib/utils/prefs.dart
@@ -1,0 +1,9 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+class VideoPrefs {
+  static const _kMuted = 'video.muted';
+  static Future<bool> getMuted() async =>
+      (await SharedPreferences.getInstance()).getBool(_kMuted) ?? true;
+  static Future<void> setMuted(bool v) async =>
+      (await SharedPreferences.getInstance()).setBool(_kMuted, v);
+}

--- a/lib/video/video_lifecycle.dart
+++ b/lib/video/video_lifecycle.dart
@@ -1,0 +1,70 @@
+import 'dart:async';
+import 'package:flutter/foundation.dart';
+import 'package:video_player/video_player.dart';
+
+class VideoLifecycle {
+  VideoPlayerController? _current;
+  VideoPlayerController? _next;
+  Uri? _currentUri;
+  bool _disposed = false;
+
+  VideoPlayerController? get controller => _current;
+  Uri? get uri => _currentUri;
+
+  Future<void> init(Uri uri, {bool muted = true}) async {
+    await _swapTo(await _create(uri, muted: muted));
+  }
+
+  Future<void> prefetch(Uri uri, {bool muted = true}) async {
+    _next?.dispose();
+    _next = await _create(uri, muted: muted);
+  }
+
+  Future<void> advanceToPrefetched() async {
+    if (_next == null) return;
+    await _swapTo(_next!);
+    _next = null;
+  }
+
+  Future<void> retry({bool muted = true}) async {
+    if (_currentUri == null) return;
+    await _swapTo(await _create(_currentUri!, muted: muted));
+  }
+
+  Future<void> setMuted(bool muted) async {
+    final c = _current;
+    if (c == null) return;
+    await c.setVolume(muted ? 0.0 : 1.0);
+  }
+
+  Future<void> dispose() async {
+    _disposed = true;
+    await _current?.dispose();
+    await _next?.dispose();
+    _current = null;
+    _next = null;
+  }
+
+  Future<VideoPlayerController> _create(Uri uri, {required bool muted}) async {
+    final c = VideoPlayerController.networkUrl(uri);
+    await c.initialize();
+    await c.setLooping(true);
+    await c.setVolume(muted ? 0.0 : 1.0);
+    // On web, kick playback muted first to satisfy autoplay policies.
+    await c.play();
+    return c;
+  }
+
+  Future<void> _swapTo(VideoPlayerController next) async {
+    if (_disposed) {
+      await next.dispose();
+      return;
+    }
+    final old = _current;
+    _current = next;
+    _currentUri = next.dataSourceUri;
+    if (old != null) {
+      unawaited(old.dispose());
+    }
+  }
+}

--- a/lib/video/video_lifecycle.dart
+++ b/lib/video/video_lifecycle.dart
@@ -1,34 +1,36 @@
 import 'dart:async';
-import 'package:flutter/foundation.dart';
 import 'package:video_player/video_player.dart';
 
 class VideoLifecycle {
   VideoPlayerController? _current;
   VideoPlayerController? _next;
   Uri? _currentUri;
+  Uri? _nextUri;
   bool _disposed = false;
 
   VideoPlayerController? get controller => _current;
   Uri? get uri => _currentUri;
 
   Future<void> init(Uri uri, {bool muted = true}) async {
-    await _swapTo(await _create(uri, muted: muted));
+    await _swapTo(await _create(uri, muted: muted), uri);
   }
 
   Future<void> prefetch(Uri uri, {bool muted = true}) async {
     _next?.dispose();
     _next = await _create(uri, muted: muted);
+    _nextUri = uri;
   }
 
   Future<void> advanceToPrefetched() async {
-    if (_next == null) return;
-    await _swapTo(_next!);
+    if (_next == null || _nextUri == null) return;
+    await _swapTo(_next!, _nextUri!);
     _next = null;
+    _nextUri = null;
   }
 
   Future<void> retry({bool muted = true}) async {
     if (_currentUri == null) return;
-    await _swapTo(await _create(_currentUri!, muted: muted));
+    await _swapTo(await _create(_currentUri!, muted: muted), _currentUri!);
   }
 
   Future<void> setMuted(bool muted) async {
@@ -43,6 +45,8 @@ class VideoLifecycle {
     await _next?.dispose();
     _current = null;
     _next = null;
+    _currentUri = null;
+    _nextUri = null;
   }
 
   Future<VideoPlayerController> _create(Uri uri, {required bool muted}) async {
@@ -55,14 +59,14 @@ class VideoLifecycle {
     return c;
   }
 
-  Future<void> _swapTo(VideoPlayerController next) async {
+  Future<void> _swapTo(VideoPlayerController next, Uri uri) async {
     if (_disposed) {
       await next.dispose();
       return;
     }
     final old = _current;
     _current = next;
-    _currentUri = next.dataSourceUri;
+    _currentUri = uri;
     if (old != null) {
       unawaited(old.dispose());
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,8 @@ dependencies:
   file_picker: ^8.0.0
   hive: ^2.2.3
   hive_flutter: ^1.1.0
-  shared_preferences: any
+  shared_preferences: ^2.3.2
+  visibility_detector: ^0.4.0+2
   collection: any
   equatable: any
   web_socket_channel: ^2.4.5

--- a/test/ui/action_stack_density_test.dart
+++ b/test/ui/action_stack_density_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter/rendering.dart';
 import 'package:nostr_video/ui/home/home_page.dart';
 import 'package:nostr_video/ui/home/widgets/overlay_cluster.dart';
 import 'package:nostr_video/ui/overlay/widgets/action_button.dart';
+import 'package:nostr_video/utils/capabilities.dart';
 import '../test_helpers/test_video_scope.dart';
 
 void main() {
@@ -14,8 +15,9 @@ void main() {
     );
     await t.pumpAndSettle();
 
-    // Ensure the six actions exist
-    expect(find.byType(ActionButton), findsNWidgets(6));
+    // Ensure the expected number of actions exist
+    final expected = Capabilities.shareSupported ? 6 : 5;
+    expect(find.byType(ActionButton), findsNWidgets(expected));
 
     final clusterBox =
         find.byType(OverlayCluster).evaluate().first.renderObject as RenderBox;

--- a/test/ui/action_stack_layout_test.dart
+++ b/test/ui/action_stack_layout_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:nostr_video/ui/home/home_page.dart';
 import 'package:nostr_video/ui/overlay/widgets/action_button.dart';
+import 'package:nostr_video/utils/capabilities.dart';
 import '../test_helpers/test_video_scope.dart';
 import 'package:network_image_mock/network_image_mock.dart';
 
@@ -15,7 +16,8 @@ void main() {
       if (kIsWeb) {
         expect(find.byTooltip('Like'), findsOneWidget);
       } else {
-        expect(find.byType(ActionButton), findsNWidgets(6));
+        final expected = Capabilities.shareSupported ? 6 : 5;
+        expect(find.byType(ActionButton), findsNWidgets(expected));
       }
       final boxes =
           find.byWidgetPredicate((w) => w is SizedBox && w.width == 48 && w.height == 48);


### PR DESCRIPTION
## Summary
- add video lifecycle manager and visibility-aware video tile
- persist mute state and expose capability helpers
- hide share button when the Web Share API isn't available

## Testing
- `dart format lib/utils/prefs.dart lib/utils/capabilities.dart lib/video/video_lifecycle.dart lib/ui/widgets/video_tile.dart lib/ui/home/widgets/overlay_cluster.dart lib/ui/home/home_page.dart pubspec.yaml` *(command not found)*
- `dart analyze` *(command not found)*
- `apt-get install -y dart` *(package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a19f0415bc833185d7a59eb703a3b8