### PR TITLE
ui(overlay): stack action counts below icons

### DIFF
--- a/lib/ui/overlay/widgets/action_button.dart
+++ b/lib/ui/overlay/widgets/action_button.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/rendering.dart';
-import '../../design/tokens.dart';
 import '../../widgets/app_icon.dart';
 
 class ActionButton extends StatelessWidget {
@@ -20,50 +18,44 @@ class ActionButton extends StatelessWidget {
     this.color = Colors.white,
   });
 
-  double _btnSize(BuildContext context) {
-    // On the web with a mouse, allow 40px; otherwise 48px for touch.
-    final kind = RendererBinding.instance.mouseTracker.mouseIsConnected;
-    return kind ? T.btnSizeMouse : T.btnSizeTouch;
-  }
-
   @override
   Widget build(BuildContext context) {
-    final size = _btnSize(context);
+    final hasLabel = label != null && label!.isNotEmpty;
+    final textStyle = Theme.of(context).textTheme.labelSmall?.copyWith(
+          color: Colors.white60,
+          height: 1.1,
+          fontWeight: FontWeight.w500,
+        );
 
-    final core = Row(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        InkResponse(
-          onTap: onTap,
-          radius: size / 2,
-          child: SizedBox(
-            width: size,
-            height: size,
-            child: Center(child: AppIcon(icon, size: 24, color: color)),
-          ),
+    final core = InkResponse(
+      onTap: onTap,
+      radius: 28,
+      containedInkWell: true,
+      child: SizedBox(
+        width: 44,
+        height: 44,
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            AppIcon(icon, size: 24, color: color),
+            if (hasLabel) ...[
+              const SizedBox(height: 4),
+              SizedBox(
+                height: 16,
+                child: Text(
+                  label!,
+                  maxLines: 1,
+                  textAlign: TextAlign.center,
+                  overflow: TextOverflow.clip,
+                  style: textStyle,
+                ),
+              ),
+            ],
+          ],
         ),
-        if (label != null) ...[
-          const SizedBox(width: T.rowGap),
-          ConstrainedBox(
-            constraints: const BoxConstraints(minWidth: 24),
-            child: Text(
-              label!,
-              maxLines: 1,
-              overflow: TextOverflow.fade,
-              softWrap: false,
-              textAlign: TextAlign.right,
-              style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                    fontSize: 11,
-                    height: 1.0,
-                    color: color.withValues(alpha: 0.9),
-                    fontWeight: FontWeight.w600,
-                    letterSpacing: 0.1,
-                  ),
-            ),
-          ),
-        ],
-      ],
+      ),
     );
 
     return (kIsWeb && tooltip != null)

--- a/test/ui/action_stack_layout_test.dart
+++ b/test/ui/action_stack_layout_test.dart
@@ -8,7 +8,7 @@ import '../test_helpers/test_video_scope.dart';
 import 'package:network_image_mock/network_image_mock.dart';
 
 void main() {
-  testWidgets('action buttons have 48x48 min hit targets and compact gaps', (t) async {
+  testWidgets('action buttons have 44x44 hit targets and compact gaps', (t) async {
     await mockNetworkImagesFor(() async {
       await t.pumpWidget(
           const TestVideoApp(child: MaterialApp(home: HomePage())));
@@ -20,7 +20,7 @@ void main() {
         expect(find.byType(ActionButton), findsNWidgets(expected));
       }
       final boxes =
-          find.byWidgetPredicate((w) => w is SizedBox && w.width == 48 && w.height == 48);
+          find.byWidgetPredicate((w) => w is SizedBox && w.width == 44 && w.height == 44);
       expect(boxes, findsWidgets);
     });
   });


### PR DESCRIPTION
## Summary
- arrange overlay action buttons vertically so counts appear beneath their icons
- add compact 44x44 tap target with muted count text
- adjust layout test for new button dimensions

## Testing
- `flutter test` *(fails: command not found)*
- `dart format lib/ui/overlay/widgets/action_button.dart test/ui/action_stack_layout_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a23990e6008331b9ec6d0b4288a293