### PR TITLE
Wire account menu to notifications and settings pages

### DIFF
--- a/lib/app/routes.dart
+++ b/lib/app/routes.dart
@@ -1,0 +1,13 @@
+/// Centralized route names used across the app.
+class AppRoutes {
+  AppRoutes._();
+
+  static const notifications = '/notifications';
+  static const settings = '/settings';
+}
+
+/// Minimal labels for UI tests & semantics.
+class AppLabels {
+  static const notificationsTitle = 'Notifications';
+  static const settingsTitle = 'Settings';
+}

--- a/lib/core/app_router.dart
+++ b/lib/core/app_router.dart
@@ -1,13 +1,21 @@
 import 'package:flutter/material.dart';
+import '../app/routes.dart';
 import '../ui/pages/tag_feed_page.dart';
 import '../ui/pages/profile_feed_page.dart';
 import '../ui/pages/event_view_page.dart';
+import '../ui/pages/notifications_page.dart';
+import '../ui/pages/settings_page.dart';
 
 class AppRouter {
   static final navKey = GlobalKey<NavigatorState>();
 
   static Route<dynamic> onGenerate(RouteSettings s) {
     switch (s.name) {
+      case AppRoutes.notifications:
+        return MaterialPageRoute(
+            builder: (_) => const NotificationsPage());
+      case AppRoutes.settings:
+        return MaterialPageRoute(builder: (_) => const SettingsPage());
       case '/tag':
         return MaterialPageRoute(
             builder: (_) => TagFeedPage(tag: s.arguments as String));

--- a/lib/ui/overlay/widgets/account_menu.dart
+++ b/lib/ui/overlay/widgets/account_menu.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../sheet_gate.dart';
 import '../../../session/user_session.dart';
+import '../../../app/routes.dart';
 
 Future<void> showAccountMenu(BuildContext context) {
   return SheetGate.openAccountMenu(context, accountMenuContent);
@@ -8,6 +9,13 @@ Future<void> showAccountMenu(BuildContext context) {
 
 Widget accountMenuContent(BuildContext context) {
   final p = userSession.current.value;
+  void navigateAfterClose(String route) {
+    Navigator.of(context, rootNavigator: true).maybePop();
+    Future.microtask(() {
+      Navigator.of(context, rootNavigator: true).pushNamed(route);
+    });
+  }
+
   return SafeArea(
     child: Padding(
       padding: const EdgeInsets.all(16),
@@ -39,18 +47,12 @@ Widget accountMenuContent(BuildContext context) {
             leading: const Icon(Icons.notifications, color: Colors.white70),
             title:
                 const Text('Notifications', style: TextStyle(color: Colors.white)),
-            onTap: () {
-              Navigator.pop(context);
-              // TODO: open notifications
-            },
+            onTap: () => navigateAfterClose(AppRoutes.notifications),
           ),
           ListTile(
             leading: const Icon(Icons.settings, color: Colors.white70),
             title: const Text('Settings', style: TextStyle(color: Colors.white)),
-            onTap: () {
-              Navigator.pop(context);
-              // TODO: open settings
-            },
+            onTap: () => navigateAfterClose(AppRoutes.settings),
           ),
         ],
       ),

--- a/lib/ui/overlay/widgets/account_menu.dart
+++ b/lib/ui/overlay/widgets/account_menu.dart
@@ -10,9 +10,10 @@ Future<void> showAccountMenu(BuildContext context) {
 Widget accountMenuContent(BuildContext context) {
   final p = userSession.current.value;
   void navigateAfterClose(String route) {
-    Navigator.of(context, rootNavigator: true).maybePop();
+    final navigator = Navigator.of(context, rootNavigator: true);
+    navigator.maybePop();
     Future.microtask(() {
-      Navigator.of(context, rootNavigator: true).pushNamed(route);
+      navigator.pushNamed(route);
     });
   }
 

--- a/lib/ui/pages/notifications_page.dart
+++ b/lib/ui/pages/notifications_page.dart
@@ -1,0 +1,40 @@
+import 'package:flutter/material.dart';
+import '../../app/routes.dart';
+
+/// Placeholder Notifications screen.
+/// Data wiring (repo/stream) will land in a later PR.
+class NotificationsPage extends StatelessWidget {
+  const NotificationsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(AppLabels.notificationsTitle),
+      ),
+      body: const _EmptyNotifications(),
+    );
+  }
+}
+
+class _EmptyNotifications extends StatelessWidget {
+  const _EmptyNotifications();
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          const Icon(Icons.notifications_none, size: 48),
+          const SizedBox(height: 12),
+          Text(
+            'Your Nostr notifications will appear here.',
+            style: Theme.of(context).textTheme.bodyMedium,
+            textAlign: TextAlign.center,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/ui/pages/settings_page.dart
+++ b/lib/ui/pages/settings_page.dart
@@ -1,0 +1,89 @@
+import 'package:flutter/material.dart';
+import '../../app/routes.dart';
+
+/// Minimal Settings screen scaffold.
+/// Actual settings groups (keys, relays, safety, notifications) will be added in follow-ups.
+class SettingsPage extends StatelessWidget {
+  const SettingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text(AppLabels.settingsTitle),
+      ),
+      body: ListView(
+        padding: const EdgeInsets.symmetric(vertical: 12),
+        children: const [
+          _SettingsGroup(
+            title: 'Account',
+            children: [
+              _SettingsTile('Profile & Keys'),
+              _SettingsTile('Relays'),
+            ],
+          ),
+          _SettingsGroup(
+            title: 'Content & Safety',
+            children: [
+              _SettingsTile('Muted Users'),
+              _SettingsTile('Media Preferences'),
+            ],
+          ),
+          _SettingsGroup(
+            title: 'Notifications',
+            children: [
+              _SettingsTile('Mentions & Likes'),
+              _SettingsTile('Zaps'),
+            ],
+          ),
+          _SettingsGroup(
+            title: 'About',
+            children: [
+              _SettingsTile('App Version'),
+              _SettingsTile('Licenses'),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _SettingsGroup extends StatelessWidget {
+  final String title;
+  final List<Widget> children;
+  const _SettingsGroup({required this.title, required this.children});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Padding(
+            padding: const EdgeInsets.fromLTRB(16, 8, 16, 4),
+            child: Text(title, style: theme.textTheme.titleMedium),
+          ),
+          ...children,
+          const SizedBox(height: 8),
+          const Divider(height: 0),
+        ],
+      ),
+    );
+  }
+}
+
+class _SettingsTile extends StatelessWidget {
+  final String label;
+  const _SettingsTile(this.label);
+
+  @override
+  Widget build(BuildContext context) {
+    return ListTile(
+      title: Text(label),
+      onTap: () {}, // wired later
+    );
+  }
+}

--- a/test/ui/navigation_account_menu_test.dart
+++ b/test/ui/navigation_account_menu_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:nostr_video/app/routes.dart';
+import 'package:nostr_video/ui/pages/notifications_page.dart';
+import 'package:nostr_video/ui/pages/settings_page.dart';
+import 'package:nostr_video/ui/overlay/widgets/account_menu.dart';
+
+void main() {
+  testWidgets('Account menu items navigate to pages', (tester) async {
+    await tester.pumpWidget(MaterialApp(
+      routes: {
+        AppRoutes.notifications: (_) => const NotificationsPage(),
+        AppRoutes.settings: (_) => const SettingsPage(),
+      },
+      home: Builder(
+        builder: (context) => Scaffold(
+          body: Center(
+            child: ElevatedButton(
+              key: const Key('open_account_menu'),
+              onPressed: () {
+                showModalBottomSheet(
+                  context: context,
+                  useRootNavigator: true,
+                  builder: accountMenuContent,
+                );
+              },
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      ),
+    ));
+
+    await tester.tap(find.byKey(const Key('open_account_menu')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Notifications'));
+    await tester.pumpAndSettle();
+    expect(find.text(AppLabels.notificationsTitle), findsOneWidget);
+
+    Navigator.of(tester.element(find.text(AppLabels.notificationsTitle))).pop();
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const Key('open_account_menu')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.text('Settings'));
+    await tester.pumpAndSettle();
+    expect(find.text(AppLabels.settingsTitle), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- Add central `AppRoutes` and `AppLabels` for notifications and settings
- Scaffold `NotificationsPage` and `SettingsPage`
- Handle new routes in `AppRouter` and wire account menu navigation
- Add widget test for account menu navigation

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a249270a9c8331aeb86b8a4bac5ad1